### PR TITLE
Only move versions file for tpm filtering if that part is executed

### DIFF
--- a/w_smart-seq_clustering/run_flavour.sh
+++ b/w_smart-seq_clustering/run_flavour.sh
@@ -39,7 +39,8 @@ if [ $tpm_filtering = "True" ]; then
                          -P $params_tpm_filtering_json \
                          -H scanpy-tpm-filtering-$EXP_ID \
                          -G $GALAXY_INSTANCE
+
+  mv $WORKDIR/software_versions_galaxy.txt $WORKDIR/filter_tpms_software_versions.txt
 fi
-mv $WORKDIR/software_versions_galaxy.txt $WORKDIR/filter_tpms_software_versions.txt
 
 choose_resolution_per_clustering.py --clusters-path $WORKDIR --output-dir $WORKDIR


### PR DESCRIPTION
Based on the example directory you provided @pinin4fjords this PR should fix the issue with the missing file and give you a link to access the history (by pointing to a newer version of the Galaxy workflow executor).