### PR TITLE
Remove upper limit on droplet umi counts

### DIFF
--- a/w_droplet_clustering/scanpy_clustering_params.json
+++ b/w_droplet_clustering/scanpy_clustering_params.json
@@ -93,7 +93,7 @@
     "parameters_0|max": "1000000000.0",
     "parameters_1|name": "n_counts",
     "parameters_1|min": "0.0",
-    "parameters_1|max": "10000.0",
+    "parameters_1|max": "1000000000.0",
     "input_format": "anndata",
     "input_obj_file": {
       "__class__": "ConnectedValue"


### PR DESCRIPTION
This PR removes the upper limit on total UMI counts for droplet experiments, since the choice seemed arbitrary, and was removing non-trivial segments of data unlikely to be doublets.