### PR TITLE
[WIP] Feature/update for new scanpy scripts

### DIFF
--- a/w_droplet_clustering/scanpy_clustering_params.json
+++ b/w_droplet_clustering/scanpy_clustering_params.json
@@ -1,306 +1,355 @@
 {
-  "find_clusters": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "random_seed": "1234",
-      "default": "false",
-      "use_weights": "false",
-      "resolution_file": {
-        "__class__": "ConnectedValue"
-      },
-      "key_added": "louvain",
-      "__current_case__": 1,
-      "restrict_to": "",
-      "flavor": "vtraag",
-      "resolution": "1.0"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "output_cluster": "true",
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "resolution": {
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "__page__": null,
-    "__rerun_remap_job_id__": null,
-    "parameter_name": "resolution",
-    "input_type": {
-      "input_values": "0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0",
-      "parameter_values": "list_comma_separated_values",
-      "__current_case__": 0
+    "barcodes": {}, 
+    "filter_cells": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "categories": [], 
+        "export_mtx": "true", 
+        "gene_name": "gene_symbols", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "parameters": [
+            {
+                "__index__": 0, 
+                "max": "1000000000.0", 
+                "min": "400.0", 
+                "name": "n_genes"
+            }, 
+            {
+                "__index__": 1, 
+                "max": "1000000000.0", 
+                "min": "0.0", 
+                "name": "n_counts"
+            }
+        ], 
+        "subsets": []
+    }, 
+    "filter_genes": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "categories": [], 
+        "export_mtx": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "parameters": [
+            {
+                "__index__": 0, 
+                "max": "1000000000.0", 
+                "min": "3.0", 
+                "name": "n_cells"
+            }
+        ], 
+        "subsets": [
+            {
+                "__index__": 0, 
+                "name": "index", 
+                "subset": {
+                    "__class__": "ConnectedValue"
+                }
+            }
+        ]
+    }, 
+    "find_clusters": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "method": "louvain", 
+        "output_cluster": "true", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "directed": "true", 
+            "key_added": "", 
+            "random_seed": "1234", 
+            "resolution": "1.0", 
+            "resolution_file": {
+                "__class__": "ConnectedValue"
+            }, 
+            "restrict_to": "", 
+            "use_graph": "neighbors", 
+            "use_weights": "false"
+        }
+    }, 
+    "find_markers": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "groupby": "louvain", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "n_genes": "100", 
+        "output_format": "anndata", 
+        "output_markers": "true", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "groups": "", 
+            "max_out_group_fraction": "1.0", 
+            "method": "t-test_overestim_var", 
+            "min_fold_change": "1.0", 
+            "min_in_group_fraction": "0.0", 
+            "rankby_abs": "false", 
+            "reference": "rest", 
+            "use_raw": "true"
+        }
+    }, 
+    "find_variable_genes": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "filter": "false", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "method": {
+            "__current_case__": 0, 
+            "flavor": "seurat", 
+            "max_disp": "1000000000.0", 
+            "max_mean": "1000000000.0", 
+            "min_disp": "0.5", 
+            "min_mean": "0.0125"
+        }, 
+        "n_bin": "20", 
+        "output_format": "anndata"
+    }, 
+    "genes": {}, 
+    "gtf": {}, 
+    "matrix": {}, 
+    "neighbours": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "knn": "true", 
+            "method": "umap", 
+            "n_neighbours": "15", 
+            "n_pcs": "50", 
+            "random_seed": "0", 
+            "use_rep": "X_pca"
+        }
+    }, 
+    "normalise_data": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "export_mtx": "true", 
+        "fraction": "1.0", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "RuntimeValue"
+        }, 
+        "log_transform": "false", 
+        "output_format": "anndata", 
+        "save_raw": "true", 
+        "scale_factor": "1000000.0"
+    }, 
+    "normalise_data_internal": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "export_mtx": "false", 
+        "fraction": "1.0", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "log_transform": "true", 
+        "output_format": "anndata", 
+        "save_raw": "true", 
+        "scale_factor": "1000000.0"
+    }, 
+    "perplexity": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "perplexity"
+    }, 
+    "plot_pca": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "basis": "pca", 
+        "color_by": "n_genes", 
+        "fig_dpi": "80", 
+        "fig_fontsize": "10", 
+        "fig_frame": "false", 
+        "fig_size": "7,7", 
+        "fig_title": "PCA", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "legend_fontsize": "10", 
+        "legend_loc": "right margin", 
+        "point_size": "", 
+        "use_raw": "true"
+    }, 
+    "plot_umap": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "basis": "umap", 
+        "color_by": "n_genes", 
+        "fig_dpi": "80", 
+        "fig_fontsize": "10", 
+        "fig_frame": "false", 
+        "fig_size": "7,7", 
+        "fig_title": "UMAP", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "legend_fontsize": "10", 
+        "legend_loc": "right margin", 
+        "point_size": "", 
+        "use_raw": "true"
+    }, 
+    "resolution": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "resolution"
+    }, 
+    "run_pca": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "extra_outputs": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "n_pcs": "50", 
+        "output_format": "anndata", 
+        "run_mode": {
+            "__current_case__": 1, 
+            "chunked": "false", 
+            "random_seed": "1234", 
+            "svd_solver": "arpack", 
+            "zero_center": "false"
+        }
+    }, 
+    "run_tsne": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "embeddings": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "key_added": "", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "early_exaggeration": "12.0", 
+            "fast_tsne": "false", 
+            "learning_rate": "400.0", 
+            "n_job": "", 
+            "n_pc": "", 
+            "perplexity": "30.0", 
+            "perplexity_file": {
+                "__class__": "ConnectedValue"
+            }, 
+            "random_seed": "1234"
+        }, 
+        "use_rep": "auto"
+    }, 
+    "run_umap": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "embeddings": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "key_added": "", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "alpha": "1.0", 
+            "default": "false", 
+            "gamma": "1.0", 
+            "init_pos": "spectral", 
+            "maxiter": "", 
+            "min_dist": "0.5", 
+            "n_components": "2", 
+            "negative_sample_rate": "5", 
+            "random_seed": "0", 
+            "spread": "1.0"
+        }, 
+        "use_graph": "neighbors"
     }
-  },
-  "filter_genes": {
-    "subset": {
-      "__class__": "ConnectedValue"
-    },
-    "__page__": null,
-    "parameters_0|min": "3",
-    "parameters_0|name": "n_cells",
-    "parameters_0|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "neighbours": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "knn": "true",
-      "default": "false",
-      "metric": "euclidean",
-      "use_rep": "X_pca",
-      "random_seed": "1234",
-      "n_neighbours": "15",
-      "__current_case__": 1,
-      "n_pcs": "50",
-      "method": "umap"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "filter_cells": {
-    "subset": {
-      "__class__": "RuntimeValue"
-    },
-    "__page__": null,
-    "parameters_0|name": "n_genes",
-    "parameters_0|min": "400",
-    "parameters_0|max": "1000000000.0",
-    "parameters_1|name": "n_counts",
-    "parameters_1|min": "0.0",
-    "parameters_1|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "run_tsne": {
-    "__page__": null,
-    "embeddings": "true",
-    "input_format": "anndata",
-    "settings": {
-      "random_seed": "1234",
-      "perplexity_file": {
-        "__class__": "ConnectedValue"
-      },
-      "learning_rate": "400.0",
-      "default": "false",
-      "use_rep": "auto",
-      "__current_case__": 1,
-      "n_job": "",
-      "early_exaggeration": "12.0",
-      "perplexity": "30.0",
-      "n_pc": "",
-      "fast_tsne": "false"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "false",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "false",
-      "color_by": "",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "run_umap": {
-    "__page__": null,
-    "embeddings": "true",
-    "input_format": "anndata",
-    "settings": {
-      "a": "",
-      "b": "",
-      "random_seed": "1234",
-      "min_dist": "0.5",
-      "default": "false",
-      "spread": "1.0",
-      "init_pos": "spectral",
-      "__current_case__": 1,
-      "maxiter": "",
-      "alpha": "1.0",
-      "negative_sample_rate": "5",
-      "gamma": "1.0",
-      "n_components": "2"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "true",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "false",
-      "color_by": "",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "perplexity": {
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "__page__": null,
-    "__rerun_remap_job_id__": null,
-    "parameter_name": "perplexity",
-    "input_type": {
-      "input_values": "1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50",
-      "parameter_values": "list_comma_separated_values",
-      "__current_case__": 0
-    }
-  },
-  "find_markers": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "__current_case__": 1,
-      "reference": "rest",
-      "default": "false",
-      "use_raw": "true",
-      "method": "t-test_overestim_var",
-      "rankby_abs": "false",
-      "groups": "",
-      "groupby": "louvain"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "n_genes": "50",
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_markers": "true",
-    "output_format": "anndata"
-  },
-  "find_variable_genes": {
-    "n_top_gene": "",
-    "__page__": null,
-    "parameters_0|name": "mean",
-    "parameters_0|min": "0.0125",
-    "parameters_0|max": "1000000000.0",
-    "parameters_1|name": "disp",
-    "parameters_1|min": "3",
-    "parameters_1|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "n_bin": "20",
-    "flavor": "cell_ranger",
-    "output_format": "anndata"
-  },
-  "run_pca": {
-    "__page__": null,
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "RuntimeValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "false",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "true",
-      "color_by": "n_genes",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "extra_outputs": null,
-    "n_pcs": "50",
-    "output_format": "anndata",
-    "run_mode": {
-      "chunked": "false",
-      "random_seed": "1234",
-      "zero_center": "false",
-      "__current_case__": 1,
-      "svd_solver": "arpack"
-    }
-  },
-  "normalise_data": {
-    "__page__": null,
-    "scale_factor": "1000000.0",
-    "input_format": "anndata",
-    "save_raw": "true",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  }
 }

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -98,7 +98,7 @@
         "groupby": "louvain", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "n_genes": "100", 
         "output_format": "anndata", 
@@ -166,17 +166,13 @@
         }
     }, 
     "normalise_data": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "export_mtx": "true", 
         "fraction": "1.0", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "ConnectedValue"
+            "__class__": "RuntimeValue"
         }, 
         "log_transform": "false", 
         "output_format": "anndata", 

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -1,306 +1,359 @@
 {
-  "filter_cells": {
-    "subset": {
-      "__class__": "RuntimeValue"
-    },
-    "__page__": null,
-    "parameters_0|name": "n_genes",
-    "parameters_0|min": "400",
-    "parameters_0|max": "1000000000.0",
-    "parameters_1|name": "n_counts",
-    "parameters_1|min": "0.0",
-    "parameters_1|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "filter_genes": {
-    "subset": {
-      "__class__": "ConnectedValue"
-    },
-    "__page__": null,
-    "parameters_0|min": "3",
-    "parameters_0|name": "n_cells",
-    "parameters_0|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "find_clusters": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "random_seed": "1234",
-      "default": "false",
-      "use_weights": "false",
-      "resolution_file": {
-        "__class__": "ConnectedValue"
-      },
-      "key_added": "louvain",
-      "__current_case__": 1,
-      "restrict_to": "",
-      "flavor": "vtraag",
-      "resolution": "1.0"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "output_cluster": "true",
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "resolution": {
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "__page__": null,
-    "__rerun_remap_job_id__": null,
-    "parameter_name": "resolution",
-    "input_type": {
-      "input_values": "0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0",
-      "parameter_values": "list_comma_separated_values",
-      "__current_case__": 0
+    "barcodes": {}, 
+    "filter_cells": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "categories": [], 
+        "export_mtx": "true", 
+        "gene_name": "gene_symbols", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "parameters": [
+            {
+                "__index__": 0, 
+                "max": "1000000000.0", 
+                "min": "400.0", 
+                "name": "n_genes"
+            }, 
+            {
+                "__index__": 1, 
+                "max": "1000000000.0", 
+                "min": "0.0", 
+                "name": "n_counts"
+            }
+        ], 
+        "subsets": []
+    }, 
+    "filter_genes": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "categories": [], 
+        "export_mtx": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "parameters": [
+            {
+                "__index__": 0, 
+                "max": "1000000000.0", 
+                "min": "3.0", 
+                "name": "n_cells"
+            }
+        ], 
+        "subsets": [
+            {
+                "__index__": 0, 
+                "name": "index", 
+                "subset": {
+                    "__class__": "ConnectedValue"
+                }
+            }
+        ]
+    }, 
+    "find_clusters": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "method": "louvain", 
+        "output_cluster": "true", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "directed": "true", 
+            "key_added": "", 
+            "random_seed": "1234", 
+            "resolution": "1.0", 
+            "resolution_file": {
+                "__class__": "ConnectedValue"
+            }, 
+            "restrict_to": "", 
+            "use_graph": "neighbors", 
+            "use_weights": "false"
+        }
+    }, 
+    "find_markers": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "groupby": "louvain", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "RuntimeValue"
+        }, 
+        "n_genes": "100", 
+        "output_format": "anndata", 
+        "output_markers": "true", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "groups": "", 
+            "max_out_group_fraction": "1.0", 
+            "method": "t-test_overestim_var", 
+            "min_fold_change": "1.0", 
+            "min_in_group_fraction": "0.0", 
+            "rankby_abs": "false", 
+            "reference": "rest", 
+            "use_raw": "true"
+        }
+    }, 
+    "find_variable_genes": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "filter": "false", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "method": {
+            "__current_case__": 0, 
+            "flavor": "seurat", 
+            "max_disp": "1000000000.0", 
+            "max_mean": "1000000000.0", 
+            "min_disp": "0.5", 
+            "min_mean": "0.0125"
+        }, 
+        "n_bin": "20", 
+        "output_format": "anndata"
+    }, 
+    "genes": {}, 
+    "gtf": {}, 
+    "matrix": {}, 
+    "neighbours": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "knn": "true", 
+            "method": "umap", 
+            "n_neighbours": "15", 
+            "n_pcs": "50", 
+            "random_seed": "0", 
+            "use_rep": "X_pca"
+        }
+    }, 
+    "normalise_data": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "export_mtx": "true", 
+        "fraction": "1.0", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "log_transform": "false", 
+        "output_format": "anndata", 
+        "save_raw": "true", 
+        "scale_factor": "1000000.0"
+    }, 
+    "normalise_data_internal": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "export_mtx": "false", 
+        "fraction": "1.0", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "log_transform": "true", 
+        "output_format": "anndata", 
+        "save_raw": "true", 
+        "scale_factor": "1000000.0"
+    }, 
+    "perplexity": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "perplexity"
+    }, 
+    "plot_pca": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "basis": "pca", 
+        "color_by": "n_genes", 
+        "fig_dpi": "80", 
+        "fig_fontsize": "10", 
+        "fig_frame": "false", 
+        "fig_size": "7,7", 
+        "fig_title": "PCA", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "legend_fontsize": "10", 
+        "legend_loc": "right margin", 
+        "point_size": "", 
+        "use_raw": "true"
+    }, 
+    "plot_umap": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "basis": "umap", 
+        "color_by": "n_genes", 
+        "fig_dpi": "80", 
+        "fig_fontsize": "10", 
+        "fig_frame": "false", 
+        "fig_size": "7,7", 
+        "fig_title": "UMAP", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "legend_fontsize": "10", 
+        "legend_loc": "right margin", 
+        "point_size": "", 
+        "use_raw": "true"
+    }, 
+    "resolution": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "resolution"
+    }, 
+    "run_pca": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "extra_outputs": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "n_pcs": "50", 
+        "output_format": "anndata", 
+        "run_mode": {
+            "__current_case__": 1, 
+            "chunked": "false", 
+            "random_seed": "1234", 
+            "svd_solver": "arpack", 
+            "zero_center": "false"
+        }
+    }, 
+    "run_tsne": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "embeddings": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "key_added": "", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "early_exaggeration": "12.0", 
+            "fast_tsne": "false", 
+            "learning_rate": "400.0", 
+            "n_job": "", 
+            "n_pc": "", 
+            "perplexity": "30.0", 
+            "perplexity_file": {
+                "__class__": "ConnectedValue"
+            }, 
+            "random_seed": "1234"
+        }, 
+        "use_rep": "auto"
+    }, 
+    "run_umap": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "embeddings": "true", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
+        }, 
+        "key_added": "", 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "alpha": "1.0", 
+            "default": "false", 
+            "gamma": "1.0", 
+            "init_pos": "spectral", 
+            "maxiter": "", 
+            "min_dist": "0.5", 
+            "n_components": "2", 
+            "negative_sample_rate": "5", 
+            "random_seed": "0", 
+            "spread": "1.0"
+        }, 
+        "use_graph": "neighbors"
     }
-  },
-  "neighbours": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "knn": "true",
-      "default": "false",
-      "metric": "euclidean",
-      "use_rep": "X_pca",
-      "random_seed": "1234",
-      "n_neighbours": "15",
-      "__current_case__": 1,
-      "n_pcs": "50",
-      "method": "umap"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "run_tsne": {
-    "__page__": null,
-    "embeddings": "true",
-    "input_format": "anndata",
-    "settings": {
-      "random_seed": "1234",
-      "perplexity_file": {
-        "__class__": "ConnectedValue"
-      },
-      "learning_rate": "400.0",
-      "default": "false",
-      "use_rep": "auto",
-      "__current_case__": 1,
-      "n_job": "",
-      "early_exaggeration": "12.0",
-      "perplexity": "30.0",
-      "n_pc": "",
-      "fast_tsne": "false"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "false",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "false",
-      "color_by": "",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "run_umap": {
-    "__page__": null,
-    "embeddings": "true",
-    "input_format": "anndata",
-    "settings": {
-      "a": "",
-      "b": "",
-      "random_seed": "1234",
-      "min_dist": "0.5",
-      "default": "false",
-      "spread": "1.0",
-      "init_pos": "spectral",
-      "__current_case__": 1,
-      "maxiter": "",
-      "alpha": "1.0",
-      "negative_sample_rate": "5",
-      "gamma": "1.0",
-      "n_components": "2"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "true",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "false",
-      "color_by": "",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  },
-  "perplexity": {
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "__page__": null,
-    "__rerun_remap_job_id__": null,
-    "parameter_name": "perplexity",
-    "input_type": {
-      "input_values": "1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50",
-      "parameter_values": "list_comma_separated_values",
-      "__current_case__": 0
-    }
-  },
-  "find_markers": {
-    "__page__": null,
-    "input_format": "anndata",
-    "settings": {
-      "__current_case__": 1,
-      "reference": "rest",
-      "default": "false",
-      "use_raw": "true",
-      "method": "t-test_overestim_var",
-      "rankby_abs": "false",
-      "groups": "",
-      "groupby": "louvain"
-    },
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "n_genes": "50",
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_markers": "true",
-    "output_format": "anndata"
-  },
-  "find_variable_genes": {
-    "n_top_gene": "",
-    "__page__": null,
-    "parameters_0|name": "mean",
-    "parameters_0|min": "0.0125",
-    "parameters_0|max": "1000000000.0",
-    "parameters_1|name": "disp",
-    "parameters_1|min": "3",
-    "parameters_1|max": "1000000000.0",
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "n_bin": "20",
-    "flavor": "cell_ranger",
-    "output_format": "anndata"
-  },
-  "run_pca": {
-    "__page__": null,
-    "input_format": "anndata",
-    "input_obj_file": {
-      "__class__": "RuntimeValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "do_plotting": {
-      "plot": "false",
-      "palette": "",
-      "__current_case__": 0,
-      "use_raw": "false",
-      "arrows": "false",
-      "frameoff": "true",
-      "color_by": "n_genes",
-      "edges": "false",
-      "groups": "",
-      "components": "1,2",
-      "sort_order": "true",
-      "projection": "2d"
-    },
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "extra_outputs": null,
-    "n_pcs": "50",
-    "output_format": "anndata",
-    "run_mode": {
-      "chunked": "false",
-      "random_seed": "1234",
-      "zero_center": "false",
-      "__current_case__": 1,
-      "svd_solver": "arpack"
-    }
-  },
-  "normalise_data": {
-    "__page__": null,
-    "scale_factor": "1000000.0",
-    "input_format": "anndata",
-    "save_raw": "true",
-    "input_obj_file": {
-      "__class__": "ConnectedValue"
-    },
-    "__rerun_remap_job_id__": null,
-    "__job_resource": {
-      "__job_resource__select": "no",
-      "__current_case__": 0
-    },
-    "output_format": "anndata"
-  }
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "No TPM filtering", 
     "format-version": "0.1", 
-    "name": "Scanpy Prod 1.3 smart", 
+    "name": "Scanpy Prod 1.4.3 smart", 
     "steps": {
         "0": {
             "annotation": "", 
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 255
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 343
+                "top": 288
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "7c4b99d7-1282-4938-8532-5eea1d63a5e9"
+                    "uuid": "ab6f0758-3cf8-4f87-a17e-b6f960d9c2fd"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 431
+                "top": 376
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1d76c83e-e2b5-44e1-af4a-89d822cd624a"
+                    "uuid": "f3e6ceb8-96bf-4847-b7a7-271e316aad09"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 519
+                "top": 464
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "cdb4902b-d741-445c-a10b-890ea832b25f"
+                    "uuid": "34a26f64-55df-492a-81ed-4f278499faca"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 607
+                "top": 552
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "956fc417-f7bf-4ddf-90fa-5a451121867d"
+                    "uuid": "a545eb26-f6f8-4798-bc62-d112fbada810"
                 }
             ]
         }, 
@@ -173,7 +173,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 695
+                "top": 640
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -202,64 +202,51 @@
         }, 
         "6": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.3.2+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
             "id": 6, 
             "input_connections": {
-                "barcodes": {
-                    "id": 3, 
-                    "output_name": "output"
-                }, 
-                "genes": {
-                    "id": 2, 
-                    "output_name": "output"
-                }, 
-                "matrix": {
-                    "id": 1, 
+                "gtf_input": {
+                    "id": 4, 
                     "output_name": "output"
                 }
             }, 
             "inputs": [], 
             "label": null, 
-            "name": "Scanpy Read10x", 
+            "name": "GTF2GeneList", 
             "outputs": [
                 {
-                    "name": "output_h5", 
-                    "type": "h5"
+                    "name": "feature_annotation", 
+                    "type": "tsv"
                 }
             ], 
             "position": {
                 "left": 502, 
-                "top": 255
+                "top": 200
             }, 
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output_h5"
-                }, 
-                "HideDatasetActionoutput_h5": {
+                "HideDatasetActionfeature_annotation": {
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
-                    "output_name": "output_h5"
+                    "output_name": "feature_annotation"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.3.2+galaxy0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "tool_shed_repository": {
-                "changeset_revision": "572b6e3b2aff", 
-                "name": "scanpy_read_10x", 
+                "changeset_revision": "b6354c917ef9", 
+                "name": "gtf2gene_list", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
-            "tool_version": "1.3.2+galaxy0", 
+            "tool_state": "{\"__page__\": null, \"first_field\": \"\\\"gene_id\\\"\", \"feature_type\": \"\\\"gene\\\"\", \"fields\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"mito\": \"{\\\"__current_case__\\\": 0, \\\"mark_mito\\\": \\\"true\\\", \\\"mito_biotypes\\\": \\\"mt_trna,mt_rrna,mt_trna_pseudogene\\\", \\\"mito_chr\\\": \\\"mt,mitochondrion_genome,mito,m,chrM,chrMt\\\"}\", \"version_transcripts\": \"\\\"false\\\"\", \"cdnas\": \"{\\\"__current_case__\\\": 1, \\\"filter_cdnas\\\": \\\"false\\\"}\", \"noheader\": \"\\\"false\\\"\", \"gtf_input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_version": "1.42.1+galaxy4", 
             "type": "tool", 
-            "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
+            "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
             "workflow_outputs": []
         }, 
         "7": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
             "id": 7, 
             "input_connections": {
@@ -273,62 +260,72 @@
             "name": "GTF2GeneList", 
             "outputs": [
                 {
-                    "name": "gene_list", 
+                    "name": "feature_annotation", 
                     "type": "tsv"
                 }
             ], 
             "position": {
                 "left": 502, 
-                "top": 469
+                "top": 337
             }, 
             "post_job_actions": {
-                "DeleteIntermediatesActiongene_list": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "gene_list"
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    }, 
+                    "action_type": "ChangeDatatypeAction", 
+                    "output_name": "feature_annotation"
                 }, 
-                "HideDatasetActiongene_list": {
+                "HideDatasetActionfeature_annotation": {
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
-                    "output_name": "gene_list"
+                    "output_name": "feature_annotation"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "tool_shed_repository": {
-                "changeset_revision": "040d4b3a19d5", 
+                "changeset_revision": "b6354c917ef9", 
                 "name": "gtf2gene_list", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"gtf_input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
-            "tool_version": "1.42.1+galaxy0", 
+            "tool_state": "{\"__page__\": null, \"first_field\": \"\\\"gene_id\\\"\", \"feature_type\": \"\\\"gene\\\"\", \"fields\": \"\\\"gene_id\\\"\", \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"mito\": \"{\\\"__current_case__\\\": 1, \\\"mark_mito\\\": \\\"false\\\"}\", \"version_transcripts\": \"\\\"false\\\"\", \"cdnas\": \"{\\\"__current_case__\\\": 1, \\\"filter_cdnas\\\": \\\"false\\\"}\", \"noheader\": \"\\\"true\\\"\", \"gtf_input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_version": "1.42.1+galaxy4", 
             "type": "tool", 
-            "uuid": "34b0cd3d-fd08-42df-9f05-6407e2dc939c", 
+            "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19", 
             "workflow_outputs": []
         }, 
         "8": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.3.2+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
             "errors": null, 
             "id": 8, 
             "input_connections": {
-                "input_obj_file": {
+                "barcodes": {
+                    "id": 3, 
+                    "output_name": "output"
+                }, 
+                "gene_meta": {
                     "id": 6, 
-                    "output_name": "output_h5"
+                    "output_name": "feature_annotation"
+                }, 
+                "genes": {
+                    "id": 2, 
+                    "output_name": "output"
+                }, 
+                "matrix": {
+                    "id": 1, 
+                    "output_name": "output"
                 }
             }, 
             "inputs": [
                 {
-                    "description": "runtime parameter for tool Scanpy FilterCells", 
-                    "name": "subset"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy FilterCells", 
-                    "name": "input_obj_file"
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "cell_meta"
                 }
             ], 
-            "label": "filter_cells", 
-            "name": "Scanpy FilterCells", 
+            "label": null, 
+            "name": "Scanpy Read10x", 
             "outputs": [
                 {
                     "name": "output_h5", 
@@ -337,7 +334,69 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 255
+                "top": 200
+            }, 
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
+            "tool_shed_repository": {
+                "changeset_revision": "b021ae78ccb4", 
+                "name": "scanpy_read_10x", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy0", 
+            "type": "tool", 
+            "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output_h5", 
+                    "uuid": "e7215654-ff6a-4243-a489-643e40044b92"
+                }
+            ]
+        }, 
+        "9": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.4.3+galaxy1", 
+            "errors": null, 
+            "id": 9, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 8, 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "inputs": [], 
+            "label": "filter_cells", 
+            "name": "Scanpy FilterCells", 
+            "outputs": [
+                {
+                    "name": "output_h5", 
+                    "type": "h5"
+                }, 
+                {
+                    "name": "matrix_10x", 
+                    "type": "txt"
+                }, 
+                {
+                    "name": "genes_10x", 
+                    "type": "tsv"
+                }, 
+                {
+                    "name": "barcodes_10x", 
+                    "type": "tsv"
+                }
+            ], 
+            "position": {
+                "left": 1158, 
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -351,44 +410,51 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.3.2+galaxy0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "9f0ca1641ab2", 
+                "changeset_revision": "8e48fa9618c1", 
                 "name": "scanpy_filter_cells", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"subset\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"parameters\": \"[{\\\"__index__\\\": 0, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"400.0\\\", \\\"name\\\": \\\"n_genes\\\"}, {\\\"__index__\\\": 1, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"0.0\\\", \\\"name\\\": \\\"n_counts\\\"}]\", \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy0", 
+            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"parameters\": \"[{\\\"__index__\\\": 0, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"400.0\\\", \\\"name\\\": \\\"n_genes\\\"}, {\\\"__index__\\\": 1, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"0.0\\\", \\\"name\\\": \\\"n_counts\\\"}]\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"gene_name\": \"\\\"gene_symbols\\\"\", \"subsets\": \"[]\", \"__rerun_remap_job_id__\": null, \"categories\": \"[]\"}", 
+            "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "matrix_10x", 
+                    "uuid": "e59e41fb-4cfa-4b6b-9af4-20d1c7db9ab7"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "barcodes_10x", 
+                    "uuid": "4f535420-61b3-4330-a8f5-76797e295618"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "genes_10x", 
+                    "uuid": "90e417e1-1d39-46dd-95f6-9b0406aa23c8"
+                }
+            ]
         }, 
-        "9": {
+        "10": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 9, 
+            "id": 10, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 8, 
+                    "id": 9, 
                     "output_name": "output_h5"
                 }, 
-                "subset": {
+                "subsets_0|subset": {
                     "id": 7, 
-                    "output_name": "gene_list"
+                    "output_name": "feature_annotation"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FilterGenes", 
-                    "name": "subset"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy FilterGenes", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "filter_genes", 
             "name": "Scanpy FilterGenes", 
             "outputs": [
@@ -410,8 +476,8 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 255
+                "left": 1486, 
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -446,15 +512,15 @@
                     "output_name": "matrix_10x"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.4.3+galaxy3", 
             "tool_shed_repository": {
-                "changeset_revision": "d1b97a5d5a8d", 
+                "changeset_revision": "fa6c08064fc1", 
                 "name": "scanpy_filter_genes", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"subset\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"export_mtx\": \"\\\"true\\\"\", \"parameters\": \"[{\\\"__index__\\\": 0, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"3.0\\\", \\\"name\\\": \\\"n_cells\\\"}]\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"subsets\": \"[{\\\"__index__\\\": 0, \\\"name\\\": \\\"index\\\", \\\"subset\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"parameters\": \"[{\\\"__index__\\\": 0, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"3.0\\\", \\\"name\\\": \\\"n_cells\\\"}]\", \"__rerun_remap_job_id__\": null, \"categories\": \"[]\"}", 
+            "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "0bf4093a-ad6d-453d-87fc-b14c6a5a0126", 
             "workflow_outputs": [
@@ -475,41 +541,29 @@
                 }
             ]
         }, 
-        "10": {
+        "11": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 10, 
+            "id": 11, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 9, 
+                    "id": 10, 
                     "output_name": "output_h5"
                 }
             }, 
             "inputs": [], 
-            "label": "normalise_data", 
+            "label": "normalise_data_internal", 
             "name": "Scanpy NormaliseData", 
             "outputs": [
                 {
                     "name": "output_h5", 
                     "type": "h5"
-                }, 
-                {
-                    "name": "matrix_10x", 
-                    "type": "txt"
-                }, 
-                {
-                    "name": "genes_10x", 
-                    "type": "tsv"
-                }, 
-                {
-                    "name": "barcodes_10x", 
-                    "type": "tsv"
                 }
             ], 
             "position": {
-                "left": 1486, 
-                "top": 255
+                "left": 1814, 
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -544,52 +598,108 @@
                     "output_name": "matrix_10x"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "tool_shed_repository": {
-                "changeset_revision": "1dda36e73482", 
+                "changeset_revision": "f7322b68cc90", 
                 "name": "scanpy_normalise_data", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"export_mtx\": \"\\\"false\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"true\\\"\"}", 
+            "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "matrix_10x", 
-                    "uuid": "06f323bb-b4b9-4ce6-9456-fa6322dec509"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "barcodes_10x", 
-                    "uuid": "e1beea59-cdf6-4260-9d8a-b368c0e5d79a"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "genes_10x", 
-                    "uuid": "8abce516-9d8f-48d7-8cfc-e5e107f70061"
-                }
-            ]
+            "workflow_outputs": []
         }, 
-        "11": {
+        "12": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.3.2+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 11, 
+            "id": 12, 
             "input_connections": {
                 "input_obj_file": {
                     "id": 10, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
+            "inputs": [], 
+            "label": "normalise_data", 
+            "name": "Scanpy NormaliseData", 
+            "outputs": [
                 {
-                    "description": "runtime parameter for tool Scanpy FindVariableGenes", 
-                    "name": "input_obj_file"
+                    "name": "output_h5", 
+                    "type": "h5"
+                }, 
+                {
+                    "name": "matrix_10x", 
+                    "type": "txt"
+                }, 
+                {
+                    "name": "genes_10x", 
+                    "type": "tsv"
+                }, 
+                {
+                    "name": "barcodes_10x", 
+                    "type": "tsv"
                 }
             ], 
+            "position": {
+                "left": 1814, 
+                "top": 337
+            }, 
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "output_h5"
+                }, 
+                "HideDatasetActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
+            "tool_shed_repository": {
+                "changeset_revision": "f7322b68cc90", 
+                "name": "scanpy_normalise_data", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
+            "tool_version": "1.4.3+galaxy3", 
+            "type": "tool", 
+            "uuid": "10db47e3-d803-43f6-99ba-b2c852774527", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "matrix_10x", 
+                    "uuid": "924ac987-41db-4612-8502-6b4f91343baf"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "barcodes_10x", 
+                    "uuid": "8cf4fb49-869f-4a0a-a107-2aa04d3153e8"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "genes_10x", 
+                    "uuid": "b036950f-3abf-4f10-88ba-44d431ad765e"
+                }
+            ]
+        }, 
+        "13": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
+            "errors": null, 
+            "id": 13, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 11, 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "inputs": [], 
             "label": "find_variable_genes", 
             "name": "Scanpy FindVariableGenes", 
             "outputs": [
@@ -599,8 +709,8 @@
                 }
             ], 
             "position": {
-                "left": 1814, 
-                "top": 255
+                "left": 2142, 
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -614,51 +724,42 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.3.2+galaxy0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "305d0cbe0ffd", 
+                "changeset_revision": "d88a29e2eba6", 
                 "name": "scanpy_find_variable_genes", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"n_top_gene\": \"\\\"\\\"\", \"__page__\": null, \"parameters\": \"[{\\\"__index__\\\": 0, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"0.0125\\\", \\\"name\\\": \\\"mean\\\"}, {\\\"__index__\\\": 1, \\\"max\\\": \\\"1000000000.0\\\", \\\"min\\\": \\\"3.0\\\", \\\"name\\\": \\\"disp\\\"}]\", \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"n_bin\": \"\\\"20\\\"\", \"flavor\": \"\\\"cell_ranger\\\"\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy0", 
+            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "12": {
+        "14": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 12, 
+            "id": 14, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 11, 
+                    "id": 13, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunPCA", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "run_pca", 
             "name": "Scanpy RunPCA", 
             "outputs": [
                 {
                     "name": "output_h5", 
                     "type": "h5"
-                }, 
-                {
-                    "name": "output_png", 
-                    "type": "png"
                 }
             ], 
             "position": {
                 "left": 2470, 
-                "top": 255
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -670,43 +771,33 @@
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
-                }, 
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_png"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "5063cd7f8c89", 
+                "changeset_revision": "fe900f147809", 
                 "name": "scanpy_run_pca", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"do_plotting\": \"{\\\"__current_case__\\\": 0, \\\"arrows\\\": \\\"false\\\", \\\"color_by\\\": \\\"n_genes\\\", \\\"components\\\": \\\"1,2\\\", \\\"edges\\\": \\\"false\\\", \\\"frameoff\\\": \\\"true\\\", \\\"groups\\\": \\\"\\\", \\\"palette\\\": \\\"\\\", \\\"plot\\\": \\\"true\\\", \\\"projection\\\": \\\"2d\\\", \\\"sort_order\\\": \\\"true\\\", \\\"use_raw\\\": \\\"false\\\"}\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "13": {
+        "15": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 13, 
+            "id": 15, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 12, 
+                    "id": 14, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "neighbours", 
             "name": "Scanpy ComputeGraph", 
             "outputs": [
@@ -717,7 +808,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 255
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -731,27 +822,27 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "3d242b0d97d0", 
+                "changeset_revision": "53e6944bd162", 
                 "name": "scanpy_compute_graph", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"knn\\\": \\\"false\\\", \\\"method\\\": \\\"umap\\\", \\\"metric\\\": \\\"euclidean\\\", \\\"n_neighbours\\\": \\\"15\\\", \\\"n_pcs\\\": \\\"50\\\", \\\"random_seed\\\": \\\"0\\\", \\\"use_rep\\\": \\\"X_pca\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"knn\\\": \\\"true\\\", \\\"method\\\": \\\"umap\\\", \\\"n_neighbours\\\": \\\"15\\\", \\\"n_pcs\\\": \\\"50\\\", \\\"random_seed\\\": \\\"0\\\", \\\"use_rep\\\": \\\"X_pca\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "14": {
+        "16": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 14, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 14, 
                     "output_name": "output_h5"
                 }, 
                 "settings|perplexity_file": {
@@ -759,16 +850,7 @@
                     "output_name": "parameter_iteration"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunTSNE", 
-                    "name": "settings"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy RunTSNE", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "run_tsne", 
             "name": "Scanpy RunTSNE", 
             "outputs": [
@@ -782,8 +864,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 255
+                "left": 2798, 
+                "top": 337
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -804,15 +886,15 @@
                     "output_name": "output_embed"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "f6f189ce4ebc", 
+                "changeset_revision": "b946c0c60d4c", 
                 "name": "scanpy_run_tsne", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"early_exaggeration\\\": \\\"12.0\\\", \\\"fast_tsne\\\": \\\"false\\\", \\\"learning_rate\\\": \\\"400.0\\\", \\\"n_job\\\": \\\"\\\", \\\"n_pc\\\": \\\"\\\", \\\"perplexity\\\": \\\"30.0\\\", \\\"perplexity_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"random_seed\\\": \\\"1234\\\", \\\"use_rep\\\": \\\"auto\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"do_plotting\": \"{\\\"__current_case__\\\": 1, \\\"plot\\\": \\\"false\\\"}\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"early_exaggeration\\\": \\\"12.0\\\", \\\"fast_tsne\\\": \\\"false\\\", \\\"learning_rate\\\": \\\"400.0\\\", \\\"n_job\\\": \\\"\\\", \\\"n_pc\\\": \\\"\\\", \\\"perplexity\\\": \\\"30.0\\\", \\\"perplexity_file\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"random_seed\\\": \\\"1234\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"key_added\": \"\\\"\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"use_rep\": \"\\\"auto\\\"\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "000dc762-69f5-4fb1-bfad-15efddc3f6a4", 
             "workflow_outputs": [
@@ -823,14 +905,58 @@
                 }
             ]
         }, 
-        "15": {
+        "17": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 15, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 14, 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "inputs": [], 
+            "label": "plot_pca", 
+            "name": "Scanpy PlotEmbed", 
+            "outputs": [
+                {
+                    "name": "output_png", 
+                    "type": "png"
+                }
+            ], 
+            "position": {
+                "left": 2798, 
+                "top": 592
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput_png": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_png"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
+            "tool_shed_repository": {
+                "changeset_revision": "ddb20964072e", 
+                "name": "scanpy_plot_embed", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"legend_fontsize\": \"\\\"10\\\"\", \"point_size\": \"\\\"\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"basis\": \"\\\"pca\\\"\", \"__page__\": null, \"fig_fontsize\": \"\\\"10\\\"\", \"__rerun_remap_job_id__\": null, \"fig_frame\": \"\\\"false\\\"\", \"color_by\": \"\\\"n_genes\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fig_size\": \"\\\"7,7\\\"\", \"fig_dpi\": \"\\\"80\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"fig_title\": \"\\\"PCA\\\"\", \"legend_loc\": \"\\\"right margin\\\"\", \"use_raw\": \"\\\"true\\\"\"}", 
+            "tool_version": "1.4.3+galaxy0", 
+            "type": "tool", 
+            "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
+            "workflow_outputs": []
+        }, 
+        "18": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
+            "errors": null, 
+            "id": 18, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 15, 
                     "output_name": "output_h5"
                 }, 
                 "settings|resolution_file": {
@@ -852,8 +978,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 510
+                "left": 3145, 
+                "top": 195
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -881,15 +1007,15 @@
                     "output_name": "output_txt"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "ce27ae8a36cd", 
+                "changeset_revision": "e232ea3fff07", 
                 "name": "scanpy_find_cluster", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"flavor\\\": \\\"vtraag\\\", \\\"key_added\\\": \\\"louvain\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"resolution\\\": \\\"1.0\\\", \\\"resolution_file\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"restrict_to\\\": \\\"\\\", \\\"use_weights\\\": \\\"false\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"output_cluster\": \"\\\"true\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"directed\\\": \\\"true\\\", \\\"key_added\\\": \\\"\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"resolution\\\": \\\"1.0\\\", \\\"resolution_file\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"restrict_to\\\": \\\"\\\", \\\"use_graph\\\": \\\"neighbors\\\", \\\"use_weights\\\": \\\"false\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"output_cluster\": \"\\\"true\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null, \"method\": \"\\\"louvain\\\"\"}", 
+            "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "58aec931-0216-43b1-b4ab-177d3dc82a03", 
             "workflow_outputs": [
@@ -900,14 +1026,14 @@
                 }
             ]
         }, 
-        "16": {
+        "19": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 16, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 15, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -920,17 +1046,13 @@
                     "type": "h5"
                 }, 
                 {
-                    "name": "output_png", 
-                    "type": "png"
-                }, 
-                {
                     "name": "output_embed", 
                     "type": "csv"
                 }
             ], 
             "position": {
                 "left": 3126, 
-                "top": 765
+                "top": 455
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -943,11 +1065,6 @@
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
                 }, 
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_png"
-                }, 
                 "RenameDatasetActionoutput_embed": {
                     "action_arguments": {
                         "newname": "umap_embedd.csv"
@@ -956,15 +1073,15 @@
                     "output_name": "output_embed"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "88c1516e25e0", 
+                "changeset_revision": "01750c193a83", 
                 "name": "scanpy_run_umap", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"a\\\": \\\"\\\", \\\"alpha\\\": \\\"1.0\\\", \\\"b\\\": \\\"\\\", \\\"default\\\": \\\"false\\\", \\\"gamma\\\": \\\"1.0\\\", \\\"init_pos\\\": \\\"spectral\\\", \\\"maxiter\\\": \\\"\\\", \\\"min_dist\\\": \\\"0.5\\\", \\\"n_components\\\": \\\"2\\\", \\\"negative_sample_rate\\\": \\\"5\\\", \\\"random_seed\\\": \\\"0\\\", \\\"spread\\\": \\\"1.0\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"do_plotting\": \"{\\\"__current_case__\\\": 0, \\\"arrows\\\": \\\"false\\\", \\\"color_by\\\": \\\"\\\", \\\"components\\\": \\\"1,2\\\", \\\"edges\\\": \\\"false\\\", \\\"frameoff\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"palette\\\": \\\"\\\", \\\"plot\\\": \\\"true\\\", \\\"projection\\\": \\\"2d\\\", \\\"sort_order\\\": \\\"true\\\", \\\"use_raw\\\": \\\"false\\\"}\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"alpha\\\": \\\"1.0\\\", \\\"default\\\": \\\"false\\\", \\\"gamma\\\": \\\"1.0\\\", \\\"init_pos\\\": \\\"spectral\\\", \\\"maxiter\\\": \\\"\\\", \\\"min_dist\\\": \\\"0.5\\\", \\\"n_components\\\": \\\"2\\\", \\\"negative_sample_rate\\\": \\\"5\\\", \\\"random_seed\\\": \\\"0\\\", \\\"spread\\\": \\\"1.0\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"key_added\": \"\\\"\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"use_graph\": \"\\\"neighbors\\\"\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "a84344e4-50c9-4a6b-bc20-faa056f39fed", 
             "workflow_outputs": [
@@ -975,18 +1092,23 @@
                 }
             ]
         }, 
-        "17": {
+        "20": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.3.2+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 17, 
+            "id": 20, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 18, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1001,7 +1123,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 255
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1022,15 +1144,15 @@
                     "output_name": "output_csv"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.3.2+galaxy1", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "c608fd80ec15", 
+                "changeset_revision": "af5e4efa9e66", 
                 "name": "scanpy_find_markers", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groupby\\\": \\\"louvain\\\", \\\"groups\\\": \\\"\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null}", 
-            "tool_version": "1.3.2+galaxy1", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
             "workflow_outputs": [
@@ -1040,9 +1162,53 @@
                     "uuid": "af32de20-9cf0-4d3a-8c0d-f8ce794a96cb"
                 }
             ]
+        }, 
+        "21": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
+            "errors": null, 
+            "id": 21, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 19, 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "inputs": [], 
+            "label": "plot_umap", 
+            "name": "Scanpy PlotEmbed", 
+            "outputs": [
+                {
+                    "name": "output_png", 
+                    "type": "png"
+                }
+            ], 
+            "position": {
+                "left": 3454, 
+                "top": 388
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput_png": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_png"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
+            "tool_shed_repository": {
+                "changeset_revision": "ddb20964072e", 
+                "name": "scanpy_plot_embed", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"legend_fontsize\": \"\\\"10\\\"\", \"point_size\": \"\\\"\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"basis\": \"\\\"umap\\\"\", \"__page__\": null, \"fig_fontsize\": \"\\\"10\\\"\", \"__rerun_remap_job_id__\": null, \"fig_frame\": \"\\\"false\\\"\", \"color_by\": \"\\\"n_genes\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fig_size\": \"\\\"7,7\\\"\", \"fig_dpi\": \"\\\"80\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"fig_title\": \"\\\"UMAP\\\"\", \"legend_loc\": \"\\\"right margin\\\"\", \"use_raw\": \"\\\"true\\\"\"}", 
+            "tool_version": "1.4.3+galaxy0", 
+            "type": "tool", 
+            "uuid": "cdc5e6b0-2808-430b-8468-ddb51f90b640", 
+            "workflow_outputs": []
         }
     }, 
     "tags": [], 
-    "uuid": "2eef29cf-8c2c-4e6f-88a3-886aa32abe89", 
-    "version": 2
+    "uuid": "5e1e355f-03b9-48f9-a9b4-cb8941ba4429", 
+    "version": 18
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 288
+                "top": 303
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "ab6f0758-3cf8-4f87-a17e-b6f960d9c2fd"
+                    "uuid": "e797b05d-35c2-4d4b-b03d-9529ee07dfd5"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 376
+                "top": 391
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "f3e6ceb8-96bf-4847-b7a7-271e316aad09"
+                    "uuid": "1ce6f4d9-0f55-4753-b643-fe5be0ff0fdb"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 464
+                "top": 479
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "34a26f64-55df-492a-81ed-4f278499faca"
+                    "uuid": "8dff8582-1141-4d5b-89d6-19590106c654"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 552
+                "top": 567
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "a545eb26-f6f8-4798-bc62-d112fbada810"
+                    "uuid": "75f5d65d-0121-4438-8af9-05256cfb2ecc"
                 }
             ]
         }, 
@@ -173,7 +173,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 640
+                "top": 655
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -222,7 +222,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -266,7 +266,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -334,7 +334,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -395,14 +395,29 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 200
+                "left": 1157, 
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
                     "action_arguments": {}, 
                     "action_type": "DeleteIntermediatesAction", 
                     "output_name": "output_h5"
+                }, 
+                "HideDatasetActionbarcodes_10x": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "barcodes_10x"
+                }, 
+                "HideDatasetActiongenes_10x": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "genes_10x"
+                }, 
+                "HideDatasetActionmatrix_10x": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "matrix_10x"
                 }, 
                 "HideDatasetActionoutput_h5": {
                     "action_arguments": {}, 
@@ -421,23 +436,7 @@
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "matrix_10x", 
-                    "uuid": "e59e41fb-4cfa-4b6b-9af4-20d1c7db9ab7"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "barcodes_10x", 
-                    "uuid": "4f535420-61b3-4330-a8f5-76797e295618"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "genes_10x", 
-                    "uuid": "90e417e1-1d39-46dd-95f6-9b0406aa23c8"
-                }
-            ]
+            "workflow_outputs": []
         }, 
         "10": {
             "annotation": "", 
@@ -477,7 +476,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -563,7 +562,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -622,7 +621,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy NormaliseData", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "normalise_data", 
             "name": "Scanpy NormaliseData", 
             "outputs": [
@@ -645,7 +649,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -657,6 +661,27 @@
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
+                }, 
+                "RenameDatasetActionbarcodes_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_barcodes.tsv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "barcodes_10x"
+                }, 
+                "RenameDatasetActiongenes_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_genes.tsv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "genes_10x"
+                }, 
+                "RenameDatasetActionmatrix_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_matrix.mtx"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "matrix_10x"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
@@ -666,7 +691,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"export_mtx\": \"\\\"true\\\"\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
             "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "10db47e3-d803-43f6-99ba-b2c852774527", 
@@ -710,7 +735,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -759,7 +784,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -808,7 +833,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -865,7 +890,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -927,7 +952,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 592
+                "top": 607
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -979,7 +1004,7 @@
             ], 
             "position": {
                 "left": 3145, 
-                "top": 195
+                "top": 210
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1052,7 +1077,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 455
+                "top": 470
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1103,12 +1128,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1123,7 +1143,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1151,7 +1171,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
@@ -1185,7 +1205,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 388
+                "top": 403
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1209,6 +1229,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "5e1e355f-03b9-48f9-a9b4-cb8941ba4429", 
-    "version": 18
+    "uuid": "1bdbfa5d-6ec1-4ce7-8d26-2b7bac7ae68c", 
+    "version": 20
 }


### PR DESCRIPTION
This PR updates the clustering workflow taking into account changes made by Ni in updating scanpy-scripts. It retains as far as possible the previous parameterisations, which sometimes means overriding Ni's defaults. For example

 - The default is now to filter marker genes etc by fold change, which I don't believe we did previously, and which I have therefore disabled here.
 - We needed an additional normalisation without log-transform to generate our normalised matrix, since the new normalisation step should have log transformation to pass to the next step.

I had to restore output renamings lost on tool update/ replacement. 

I have tested that this works on a small dataset on the Galaxy GUI, and it works without error via Bioblend. 

Please don't merge without discussion- applying this will likely involve re-running all of our tertiary analysis. 