### PR TITLE
Feature/cell type differential

### DIFF
--- a/util/choose_resolution_per_clustering.py
+++ b/util/choose_resolution_per_clustering.py
@@ -33,7 +33,7 @@ def main():
     args = arg_parser.parse_args()
 
     # Pattern to extract resolution value from clusters file residing in clusters-path, supports integer or floats res.
-    clusters_file_pat = re.compile(r'clusters_resolution_(?P<resolution>\d+\.?\d*).tsv')
+    clusters_file_pat = re.compile(r'^clusters_resolution_(?P<resolution>\d+\.?\d*).tsv')
 
     clusters_to_res = {}
     # Choose resolutions and map to cluster numbers

--- a/util/choose_resolution_per_clustering.py
+++ b/util/choose_resolution_per_clustering.py
@@ -64,8 +64,8 @@ def main():
             cluster_assignment[cell] = cluster_num
         cells_clusters[clusters] = cluster_assignment
 
-        source = args.clusters_path+"/markers_clusters_resolution_"+str(resolution)+".csv"
-        dest = args.output_dir+"/markers_"+str(clusters)+".csv"
+        source = args.clusters_path+"/markers_clusters_resolution_"+str(resolution)+".tsv"
+        dest = args.output_dir+"/markers_"+str(clusters)+".tsv"
         if path.isfile(source):
             shutil.copy(source, dest)
 

--- a/w_droplet_clustering/scanpy_clustering_params.json
+++ b/w_droplet_clustering/scanpy_clustering_params.json
@@ -1,5 +1,6 @@
 {
     "barcodes": {}, 
+    "cellmeta": {}, 
     "filter_cells": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -116,11 +117,31 @@
             "use_raw": "true"
         }
     }, 
-    "find_variable_genes": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
+    "find_markers_cell_type": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "groupby": "inferred_cell_type", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "ConnectedValue"
         }, 
+        "n_genes": "100", 
+        "output_format": "anndata", 
+        "output_markers": "true", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "groups": "", 
+            "max_out_group_fraction": "1.0", 
+            "method": "t-test_overestim_var", 
+            "min_fold_change": "1.0", 
+            "min_in_group_fraction": "0.0", 
+            "rankby_abs": "false", 
+            "reference": "rest", 
+            "use_raw": "true"
+        }
+    }, 
+    "find_variable_genes": {
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "filter": "false", 
@@ -142,6 +163,16 @@
     "genes": {}, 
     "gtf": {}, 
     "matrix": {}, 
+    "n_neighbors": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "3, 5, 10, 15, 20, 25, 30, 50, 100", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "n_neighbors"
+    }, 
     "neighbours": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -165,6 +196,28 @@
             "use_rep": "X_pca"
         }
     }, 
+    "neighbours for umap": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "RuntimeValue"
+        }, 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "knn": "true", 
+            "method": "umap", 
+            "n_neighbors": "15", 
+            "n_neighbors_file": {
+                "__class__": "RuntimeValue"
+            }, 
+            "n_pcs": "50", 
+            "random_seed": "0", 
+            "use_rep": "X_pca"
+        }
+    }, 
     "normalise_data": {
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
@@ -172,7 +225,7 @@
         "fraction": "1.0", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "log_transform": "false", 
         "output_format": "anndata", 
@@ -234,29 +287,6 @@
         "point_size": "", 
         "use_raw": "true"
     }, 
-    "plot_umap": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
-        "__page__": null, 
-        "__rerun_remap_job_id__": null, 
-        "basis": "umap", 
-        "color_by": "n_genes", 
-        "fig_dpi": "80", 
-        "fig_fontsize": "10", 
-        "fig_frame": "false", 
-        "fig_size": "7,7", 
-        "fig_title": "UMAP", 
-        "input_format": "anndata", 
-        "input_obj_file": {
-            "__class__": "ConnectedValue"
-        }, 
-        "legend_fontsize": "10", 
-        "legend_loc": "right margin", 
-        "point_size": "", 
-        "use_raw": "true"
-    }, 
     "resolution": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -272,10 +302,6 @@
         "parameter_name": "resolution"
     }, 
     "run_pca": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "extra_outputs": null, 
@@ -324,16 +350,12 @@
         "use_rep": "auto"
     }, 
     "run_umap": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "embeddings": "true", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "ConnectedValue"
+            "__class__": "RuntimeValue"
         }, 
         "key_added": "", 
         "output_format": "anndata", 

--- a/w_smart-seq_clustering/scanpy_clustering_allowed_errors.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_allowed_errors.yaml
@@ -2,3 +2,5 @@ find_clusters:
   - any
 find_markers:
   - any
+find_markers_cell_type:
+  - any

--- a/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
+++ b/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
@@ -7,6 +7,9 @@ genes:
 barcodes:
   path: <BARCODES_PATH>
   type: tsv
+cellmeta:
+  path: <CELL_META_PATH>
+  type: tsv
 gtf:
   path: <GTF_PATH>
   type: gtf

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -1,5 +1,6 @@
 {
     "barcodes": {}, 
+    "cellmeta": {}, 
     "filter_cells": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -116,11 +117,31 @@
             "use_raw": "true"
         }
     }, 
-    "find_variable_genes": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
+    "find_markers_cell_type": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "groupby": "cell_type", 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "RuntimeValue"
         }, 
+        "n_genes": "100", 
+        "output_format": "anndata", 
+        "output_markers": "true", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "groups": "", 
+            "max_out_group_fraction": "1.0", 
+            "method": "t-test_overestim_var", 
+            "min_fold_change": "1.0", 
+            "min_in_group_fraction": "0.0", 
+            "rankby_abs": "false", 
+            "reference": "rest", 
+            "use_raw": "true"
+        }
+    }, 
+    "find_variable_genes": {
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "filter": "false", 
@@ -172,7 +193,7 @@
         "fraction": "1.0", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "log_transform": "false", 
         "output_format": "anndata", 
@@ -272,10 +293,6 @@
         "parameter_name": "resolution"
     }, 
     "run_pca": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "extra_outputs": null, 

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -123,7 +123,7 @@
         "groupby": "inferred_cell_type", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "n_genes": "100", 
         "output_format": "anndata", 
@@ -163,6 +163,16 @@
     "genes": {}, 
     "gtf": {}, 
     "matrix": {}, 
+    "n_neighbors": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_type": {
+            "__current_case__": 0, 
+            "input_values": "3, 5, 10, 15, 20, 25, 30, 50, 100", 
+            "parameter_values": "list_comma_separated_values"
+        }, 
+        "parameter_name": "n_neighbors"
+    }, 
     "neighbours": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -181,6 +191,28 @@
             "knn": "true", 
             "method": "umap", 
             "n_neighbours": "15", 
+            "n_pcs": "50", 
+            "random_seed": "0", 
+            "use_rep": "X_pca"
+        }
+    }, 
+    "neighbours for umap": {
+        "__page__": null, 
+        "__rerun_remap_job_id__": null, 
+        "input_format": "anndata", 
+        "input_obj_file": {
+            "__class__": "RuntimeValue"
+        }, 
+        "output_format": "anndata", 
+        "settings": {
+            "__current_case__": 1, 
+            "default": "false", 
+            "knn": "true", 
+            "method": "umap", 
+            "n_neighbors": "15", 
+            "n_neighbors_file": {
+                "__class__": "RuntimeValue"
+            }, 
             "n_pcs": "50", 
             "random_seed": "0", 
             "use_rep": "X_pca"
@@ -255,29 +287,6 @@
         "point_size": "", 
         "use_raw": "true"
     }, 
-    "plot_umap": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
-        "__page__": null, 
-        "__rerun_remap_job_id__": null, 
-        "basis": "umap", 
-        "color_by": "n_genes", 
-        "fig_dpi": "80", 
-        "fig_fontsize": "10", 
-        "fig_frame": "false", 
-        "fig_size": "7,7", 
-        "fig_title": "UMAP", 
-        "input_format": "anndata", 
-        "input_obj_file": {
-            "__class__": "ConnectedValue"
-        }, 
-        "legend_fontsize": "10", 
-        "legend_loc": "right margin", 
-        "point_size": "", 
-        "use_raw": "true"
-    }, 
     "resolution": {
         "__job_resource": {
             "__current_case__": 0, 
@@ -341,16 +350,12 @@
         "use_rep": "auto"
     }, 
     "run_umap": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "embeddings": "true", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "ConnectedValue"
+            "__class__": "RuntimeValue"
         }, 
         "key_added": "", 
         "output_format": "anndata", 

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -98,7 +98,7 @@
         "groupby": "louvain", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "n_genes": "100", 
         "output_format": "anndata", 
@@ -166,17 +166,13 @@
         }
     }, 
     "normalise_data": {
-        "__job_resource": {
-            "__current_case__": 0, 
-            "__job_resource__select": "no"
-        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "export_mtx": "true", 
         "fraction": "1.0", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "ConnectedValue"
+            "__class__": "RuntimeValue"
         }, 
         "log_transform": "false", 
         "output_format": "anndata", 

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -98,7 +98,7 @@
         "groupby": "louvain", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "ConnectedValue"
+            "__class__": "RuntimeValue"
         }, 
         "n_genes": "100", 
         "output_format": "anndata", 
@@ -166,13 +166,17 @@
         }
     }, 
     "normalise_data": {
+        "__job_resource": {
+            "__current_case__": 0, 
+            "__job_resource__select": "no"
+        }, 
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
         "export_mtx": "true", 
         "fraction": "1.0", 
         "input_format": "anndata", 
         "input_obj_file": {
-            "__class__": "RuntimeValue"
+            "__class__": "ConnectedValue"
         }, 
         "log_transform": "false", 
         "output_format": "anndata", 

--- a/w_smart-seq_clustering/scanpy_clustering_params.json
+++ b/w_smart-seq_clustering/scanpy_clustering_params.json
@@ -120,7 +120,7 @@
     "find_markers_cell_type": {
         "__page__": null, 
         "__rerun_remap_job_id__": null, 
-        "groupby": "cell_type", 
+        "groupby": "inferred_cell_type", 
         "input_format": "anndata", 
         "input_obj_file": {
             "__class__": "RuntimeValue"

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 288
+                "top": 303
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "ab6f0758-3cf8-4f87-a17e-b6f960d9c2fd"
+                    "uuid": "e797b05d-35c2-4d4b-b03d-9529ee07dfd5"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 376
+                "top": 391
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "f3e6ceb8-96bf-4847-b7a7-271e316aad09"
+                    "uuid": "1ce6f4d9-0f55-4753-b643-fe5be0ff0fdb"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 464
+                "top": 479
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "34a26f64-55df-492a-81ed-4f278499faca"
+                    "uuid": "8dff8582-1141-4d5b-89d6-19590106c654"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 552
+                "top": 567
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "a545eb26-f6f8-4798-bc62-d112fbada810"
+                    "uuid": "75f5d65d-0121-4438-8af9-05256cfb2ecc"
                 }
             ]
         }, 
@@ -173,7 +173,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 640
+                "top": 655
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -222,7 +222,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -266,7 +266,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -334,7 +334,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -395,8 +395,8 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 200
+                "left": 1157, 
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -436,23 +436,7 @@
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "matrix_10x", 
-                    "uuid": "e59e41fb-4cfa-4b6b-9af4-20d1c7db9ab7"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "barcodes_10x", 
-                    "uuid": "4f535420-61b3-4330-a8f5-76797e295618"
-                }, 
-                {
-                    "label": null, 
-                    "output_name": "genes_10x", 
-                    "uuid": "90e417e1-1d39-46dd-95f6-9b0406aa23c8"
-                }
-            ]
+            "workflow_outputs": []
         }, 
         "10": {
             "annotation": "", 
@@ -492,7 +476,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -578,7 +562,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -637,7 +621,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy NormaliseData", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "normalise_data", 
             "name": "Scanpy NormaliseData", 
             "outputs": [
@@ -660,7 +649,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -672,6 +661,27 @@
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
+                }, 
+                "RenameDatasetActionbarcodes_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_barcodes.tsv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "barcodes_10x"
+                }, 
+                "RenameDatasetActiongenes_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_genes.tsv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "genes_10x"
+                }, 
+                "RenameDatasetActionmatrix_10x": {
+                    "action_arguments": {
+                        "newname": "filtered_normalised_matrix.mtx"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "matrix_10x"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
@@ -681,7 +691,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"export_mtx\": \"\\\"true\\\"\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
             "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "10db47e3-d803-43f6-99ba-b2c852774527", 
@@ -725,7 +735,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -774,7 +784,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -823,7 +833,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -880,7 +890,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 337
+                "top": 352
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -942,7 +952,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 592
+                "top": 607
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -994,7 +1004,7 @@
             ], 
             "position": {
                 "left": 3145, 
-                "top": 195
+                "top": 210
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1067,7 +1077,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 455
+                "top": 470
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1118,12 +1128,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1138,7 +1143,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 200
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1166,7 +1171,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
@@ -1200,7 +1205,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 388
+                "top": 403
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1224,6 +1229,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "5e1e355f-03b9-48f9-a9b4-cb8941ba4429", 
-    "version": 18
+    "uuid": "1bdbfa5d-6ec1-4ce7-8d26-2b7bac7ae68c", 
+    "version": 20
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "No TPM filtering", 
     "format-version": "0.1", 
-    "name": "Scanpy Prod 1.4.3 smart (imported from uploaded file)", 
+    "name": "Scanpy Prod 1.4.3 smart (with cell type differential)", 
     "steps": {
         "0": {
             "annotation": "", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "ebaf4966-3d88-4e18-825d-272cf12fd6d5"
+                    "uuid": "41a76a46-ecf4-49a2-a6c6-bcb8e60909af"
                 }
             ]
         }, 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "83fce33c-39b3-4f6a-9403-b9a9687be6d2"
+                    "uuid": "57c9158c-2b9b-4b01-848b-ee138ef8bd8a"
                 }
             ]
         }, 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "cb354682-74cc-4d6f-afe1-f10ad27a747b"
+                    "uuid": "83718b22-8f16-4bfd-ac45-db723f089c93"
                 }
             ]
         }, 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "50588fb8-0e95-4af5-9fbe-330b563dd59f"
+                    "uuid": "48be6401-93e1-4f91-a8d5-e51c2104a757"
                 }
             ]
         }, 
@@ -179,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "12873fe6-9ede-4a7e-9905-a4cdb9c36bc4"
+                    "uuid": "3ac2d603-34d1-49a8-9a99-38469f679743"
                 }
             ]
         }, 
@@ -349,12 +349,7 @@
                     "output_name": "output"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "cell_meta"
-                }
-            ], 
+            "inputs": [], 
             "label": null, 
             "name": "Scanpy Read10x", 
             "outputs": [
@@ -381,7 +376,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
             "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
@@ -1088,12 +1083,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_markers_cell_type", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1108,18 +1098,13 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 543
+                "top": 542
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
                     "action_arguments": {}, 
                     "action_type": "DeleteIntermediatesAction", 
                     "output_name": "output_h5"
-                }, 
-                "HideDatasetActionoutput_csv": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_csv"
                 }, 
                 "HideDatasetActionoutput_h5": {
                     "action_arguments": {}, 
@@ -1141,11 +1126,17 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output_csv", 
+                    "uuid": "e78b83f6-5d7b-44f9-aeb2-f20a059bdd32"
+                }
+            ]
         }, 
         "21": {
             "annotation": "", 
@@ -1325,6 +1316,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "8a6df6f3-d7c8-406a-878c-ab5d7cdd3555", 
+    "uuid": "865f5cbb-3c68-48c2-beff-7bcc66c2c167", 
     "version": 2
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "4ba5c5bc-73fc-43b5-a5b8-62f7b7b23c4e"
+                    "uuid": "74619e35-1bde-421e-8463-39888902e2ac"
                 }
             ]
         }, 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "01487010-5d0d-4b9b-ae3d-f3b14b5c678f"
+                    "uuid": "f28cd8a6-87d7-4bb8-9b1e-48595d5f78f6"
                 }
             ]
         }, 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "d9a50636-f6e9-4a98-a545-99d562b5dda3"
+                    "uuid": "598c7cd3-32bd-40dd-8cec-916833e38dd0"
                 }
             ]
         }, 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "9be8fcb4-9584-44e4-9557-555b85cf5166"
+                    "uuid": "b53c3b3a-e66b-4398-a720-ac542673ebfa"
                 }
             ]
         }, 
@@ -719,12 +719,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindVariableGenes", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_variable_genes", 
             "name": "Scanpy FindVariableGenes", 
             "outputs": [
@@ -756,7 +751,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
             "tool_version": "1.4.3+galaxy9", 
             "type": "tool", 
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
@@ -764,7 +759,7 @@
         }, 
         "14": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
             "errors": null, 
             "id": 14, 
             "input_connections": {
@@ -773,7 +768,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy RunPCA", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "run_pca", 
             "name": "Scanpy RunPCA", 
             "outputs": [
@@ -798,15 +798,15 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
             "tool_shed_repository": {
-                "changeset_revision": "8b4dae3748d3", 
+                "changeset_revision": "2dd53b944e78", 
                 "name": "scanpy_run_pca", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
-            "tool_version": "1.4.3+galaxy0", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy10", 
             "type": "tool", 
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
@@ -1229,6 +1229,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "d5685fb9-ed12-4f69-bab6-f687104a4a2c", 
-    "version": 2
+    "uuid": "a0eb168f-09b2-4995-aada-302dbeb80dca", 
+    "version": 1
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -1141,7 +1141,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"cell_type\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -906,7 +906,7 @@
                 }, 
                 {
                     "name": "output_embed", 
-                    "type": "csv"
+                    "type": "tsv"
                 }
             ], 
             "position": {
@@ -926,7 +926,7 @@
                 }, 
                 "RenameDatasetActionoutput_embed": {
                     "action_arguments": {
-                        "newname": "tsne_#{perplexity_file}.csv"
+                        "newname": "tsne_#{perplexity_file}.tsv"
                     }, 
                     "action_type": "RenameDatasetAction", 
                     "output_name": "output_embed"
@@ -1092,8 +1092,8 @@
                     "type": "h5"
                 }, 
                 {
-                    "name": "output_csv", 
-                    "type": "csv"
+                    "name": "output_tsv", 
+                    "type": "tsv"
                 }
             ], 
             "position": {
@@ -1111,12 +1111,12 @@
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
                 }, 
-                "RenameDatasetActionoutput_csv": {
+                "RenameDatasetActionoutput_tsv": {
                     "action_arguments": {
                         "newname": "celltype_markers.csv"
                     }, 
                     "action_type": "RenameDatasetAction", 
-                    "output_name": "output_csv"
+                    "output_name": "output_tsv"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
@@ -1133,7 +1133,7 @@
             "workflow_outputs": [
                 {
                     "label": null, 
-                    "output_name": "output_csv", 
+                    "output_name": "output_tsv", 
                     "uuid": "e78b83f6-5d7b-44f9-aeb2-f20a059bdd32"
                 }
             ]
@@ -1224,8 +1224,8 @@
                     "type": "h5"
                 }, 
                 {
-                    "name": "output_csv", 
-                    "type": "csv"
+                    "name": "output_tsv", 
+                    "type": "tsv"
                 }
             ], 
             "position": {
@@ -1243,12 +1243,12 @@
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
                 }, 
-                "RenameDatasetActionoutput_csv": {
+                "RenameDatasetActionoutput_tsv": {
                     "action_arguments": {
                         "newname": "markers_#{input_obj_file}.csv"
                     }, 
                     "action_type": "RenameDatasetAction", 
-                    "output_name": "output_csv"
+                    "output_name": "output_tsv"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
@@ -1265,7 +1265,7 @@
             "workflow_outputs": [
                 {
                     "label": null, 
-                    "output_name": "output_csv", 
+                    "output_name": "output_tsv", 
                     "uuid": "af32de20-9cf0-4d3a-8c0d-f8ce794a96cb"
                 }
             ]

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "No TPM filtering", 
     "format-version": "0.1", 
-    "name": "Scanpy Prod 1.4.3 smart", 
+    "name": "Scanpy Prod 1.4.3 smart (imported from uploaded file)", 
     "steps": {
         "0": {
             "annotation": "", 
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 308
+                "top": 377
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "74619e35-1bde-421e-8463-39888902e2ac"
+                    "uuid": "ebaf4966-3d88-4e18-825d-272cf12fd6d5"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 396
+                "top": 465
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "f28cd8a6-87d7-4bb8-9b1e-48595d5f78f6"
+                    "uuid": "83fce33c-39b3-4f6a-9403-b9a9687be6d2"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 484
+                "top": 553
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "598c7cd3-32bd-40dd-8cec-916833e38dd0"
+                    "uuid": "cb354682-74cc-4d6f-afe1-f10ad27a747b"
                 }
             ]
         }, 
@@ -136,12 +136,39 @@
             "id": 4, 
             "input_connections": {}, 
             "inputs": [], 
+            "label": "cellmeta", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 200, 
+                "top": 641
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "50588fb8-0e95-4af5-9fbe-330b563dd59f"
+                }
+            ]
+        }, 
+        "5": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 5, 
+            "input_connections": {}, 
+            "inputs": [], 
             "label": "gtf", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 572
+                "top": 729
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,15 +179,15 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "b53c3b3a-e66b-4398-a720-ac542673ebfa"
+                    "uuid": "12873fe6-9ede-4a7e-9905-a4cdb9c36bc4"
                 }
             ]
         }, 
-        "5": {
+        "6": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
             "errors": null, 
-            "id": 5, 
+            "id": 6, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "resolution", 
@@ -173,7 +200,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 660
+                "top": 817
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -200,14 +227,14 @@
             "uuid": "d1228db0-6989-4ff0-92ba-1116b65cb6fb", 
             "workflow_outputs": []
         }, 
-        "6": {
+        "7": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
-            "id": 6, 
+            "id": 7, 
             "input_connections": {
                 "gtf_input": {
-                    "id": 4, 
+                    "id": 5, 
                     "output_name": "output"
                 }
             }, 
@@ -222,7 +249,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -244,14 +271,14 @@
             "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
             "workflow_outputs": []
         }, 
-        "7": {
+        "8": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
-            "id": 7, 
+            "id": 8, 
             "input_connections": {
                 "gtf_input": {
-                    "id": 4, 
+                    "id": 5, 
                     "output_name": "output"
                 }
             }, 
@@ -266,7 +293,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 357
+                "top": 426
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -295,18 +322,22 @@
             "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19", 
             "workflow_outputs": []
         }, 
-        "8": {
+        "9": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 8, 
+            "id": 9, 
             "input_connections": {
                 "barcodes": {
                     "id": 3, 
                     "output_name": "output"
                 }, 
+                "cell_meta": {
+                    "id": 4, 
+                    "output_name": "output"
+                }, 
                 "gene_meta": {
-                    "id": 6, 
+                    "id": 7, 
                     "output_name": "feature_annotation"
                 }, 
                 "genes": {
@@ -334,7 +365,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -362,14 +393,14 @@
                 }
             ]
         }, 
-        "9": {
+        "10": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 9, 
+            "id": 10, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 8, 
+                    "id": 9, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -395,8 +426,8 @@
                 }
             ], 
             "position": {
-                "left": 1157, 
-                "top": 220
+                "left": 1158, 
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -438,18 +469,18 @@
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
             "workflow_outputs": []
         }, 
-        "10": {
+        "11": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 10, 
+            "id": 11, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 9, 
+                    "id": 10, 
                     "output_name": "output_h5"
                 }, 
                 "subsets_0|subset": {
-                    "id": 7, 
+                    "id": 8, 
                     "output_name": "feature_annotation"
                 }
             }, 
@@ -476,7 +507,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -540,14 +571,14 @@
                 }
             ]
         }, 
-        "11": {
+        "12": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 11, 
+            "id": 12, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 10, 
+                    "id": 11, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -562,7 +593,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -610,14 +641,14 @@
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
             "workflow_outputs": []
         }, 
-        "12": {
+        "13": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 12, 
+            "id": 13, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 10, 
+                    "id": 11, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -644,7 +675,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 357
+                "top": 426
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -708,14 +739,14 @@
                 }
             ]
         }, 
-        "13": {
+        "14": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy9", 
             "errors": null, 
-            "id": 13, 
+            "id": 14, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 11, 
+                    "id": 12, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -730,7 +761,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -757,23 +788,18 @@
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "14": {
+        "15": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
             "errors": null, 
-            "id": 14, 
+            "id": 15, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 14, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunPCA", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "run_pca", 
             "name": "Scanpy RunPCA", 
             "outputs": [
@@ -784,7 +810,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -805,20 +831,20 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
             "tool_version": "1.4.3+galaxy10", 
             "type": "tool", 
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "15": {
+        "16": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 15, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 14, 
+                    "id": 15, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -833,7 +859,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -860,14 +886,14 @@
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "16": {
+        "17": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 16, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 14, 
+                    "id": 15, 
                     "output_name": "output_h5"
                 }, 
                 "settings|perplexity_file": {
@@ -890,7 +916,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 357
+                "top": 426
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -930,14 +956,14 @@
                 }
             ]
         }, 
-        "17": {
+        "18": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 17, 
+            "id": 18, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 14, 
+                    "id": 15, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -952,7 +978,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 612
+                "top": 681
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -974,18 +1000,18 @@
             "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
             "workflow_outputs": []
         }, 
-        "18": {
+        "19": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 18, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5"
                 }, 
                 "settings|resolution_file": {
-                    "id": 5, 
+                    "id": 6, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -1003,8 +1029,8 @@
                 }
             ], 
             "position": {
-                "left": 3145, 
-                "top": 215
+                "left": 3126, 
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1051,14 +1077,84 @@
                 }
             ]
         }, 
-        "19": {
+        "20": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
+            "errors": null, 
+            "id": 20, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 16, 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers", 
+                    "name": "input_obj_file"
+                }
+            ], 
+            "label": "find_markers_cell_type", 
+            "name": "Scanpy FindMarkers", 
+            "outputs": [
+                {
+                    "name": "output_h5", 
+                    "type": "h5"
+                }, 
+                {
+                    "name": "output_csv", 
+                    "type": "csv"
+                }
+            ], 
+            "position": {
+                "left": 3126, 
+                "top": 543
+            }, 
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "output_h5"
+                }, 
+                "HideDatasetActionoutput_csv": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_csv"
+                }, 
+                "HideDatasetActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_h5"
+                }, 
+                "RenameDatasetActionoutput_csv": {
+                    "action_arguments": {
+                        "newname": "celltype_markers.csv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "output_csv"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
+            "tool_shed_repository": {
+                "changeset_revision": "c18f446dcfbf", 
+                "name": "scanpy_find_markers", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"cell_type\\\"\"}", 
+            "tool_version": "1.4.3+galaxy1", 
+            "type": "tool", 
+            "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 
+            "workflow_outputs": []
+        }, 
+        "21": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 19, 
+            "id": 21, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1077,7 +1173,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 475
+                "top": 729
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1117,14 +1213,14 @@
                 }
             ]
         }, 
-        "20": {
+        "22": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 20, 
+            "id": 22, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 18, 
+                    "id": 19, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1143,7 +1239,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 220
+                "top": 289
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1183,14 +1279,14 @@
                 }
             ]
         }, 
-        "21": {
+        "23": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 21, 
+            "id": 23, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 19, 
+                    "id": 21, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1205,7 +1301,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 408
+                "top": 477
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1229,6 +1325,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "a0eb168f-09b2-4995-aada-302dbeb80dca", 
-    "version": 1
+    "uuid": "8a6df6f3-d7c8-406a-878c-ab5d7cdd3555", 
+    "version": 2
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -715,7 +715,7 @@
         }, 
         "13": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy9", 
             "errors": null, 
             "id": 13, 
             "input_connections": {

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -1228,7 +1228,7 @@
                 }, 
                 "RenameDatasetActionoutput_csv": {
                     "action_arguments": {
-                        "newname": "celltype_markers.csv"
+                        "newname": "celltype_markers.tsv"
                     }, 
                     "action_type": "RenameDatasetAction", 
                     "output_name": "output_csv"
@@ -1360,7 +1360,7 @@
                 }, 
                 "RenameDatasetActionoutput_csv": {
                     "action_arguments": {
-                        "newname": "markers_#{input_obj_file}.csv"
+                        "newname": "markers_#{input_obj_file}.tsv"
                     }, 
                     "action_type": "RenameDatasetAction", 
                     "output_name": "output_csv"

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true", 
     "annotation": "No TPM filtering", 
     "format-version": "0.1", 
-    "name": "Scanpy Prod 1.4.3 smart (with cell type differential)", 
+    "name": "Scanpy Prod 1.4.3 smart (with cell type differential and parameterised umap)", 
     "steps": {
         "0": {
             "annotation": "", 
@@ -20,8 +20,8 @@
                 }
             ], 
             "position": {
-                "left": 200, 
-                "top": 296
+                "left": 211, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -59,8 +59,8 @@
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 384
+                "left": 211, 
+                "top": 315
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "cc26f133-27d8-4b39-8148-bfaacce60c58"
+                    "uuid": "15257052-eada-4df6-8465-2645575a3d57"
                 }
             ]
         }, 
@@ -86,8 +86,8 @@
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 472
+                "left": 211, 
+                "top": 403
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "42750eea-2e3a-4429-9619-a2e4444e59d7"
+                    "uuid": "1c53f0c0-ac06-40e4-a25e-b04941df2d80"
                 }
             ]
         }, 
@@ -113,8 +113,8 @@
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 560
+                "left": 211, 
+                "top": 491
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "206828d5-5de8-42cd-b642-cb4a82d73a33"
+                    "uuid": "db335bbf-0fa4-4066-9c54-6e4f19eb8ff9"
                 }
             ]
         }, 
@@ -140,8 +140,8 @@
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 648
+                "left": 211, 
+                "top": 579
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1a69a544-445c-49b5-ab25-b4df89383832"
+                    "uuid": "b6f07a64-e515-4504-a4cc-15c22b2fe894"
                 }
             ]
         }, 
@@ -167,8 +167,8 @@
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 736
+                "left": 211, 
+                "top": 667
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -179,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "8ac66b0b-13b1-4f0d-95f1-780a301f5707"
+                    "uuid": "34e27a89-d4d7-40b0-894f-567d5f0ed961"
                 }
             ]
         }, 
@@ -199,8 +199,8 @@
                 }
             ], 
             "position": {
-                "left": 200, 
-                "top": 824
+                "left": 211, 
+                "top": 755
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -229,46 +229,41 @@
         }, 
         "7": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2", 
             "errors": null, 
             "id": 7, 
-            "input_connections": {
-                "gtf_input": {
-                    "id": 5, 
-                    "output_name": "output"
-                }
-            }, 
+            "input_connections": {}, 
             "inputs": [], 
-            "label": null, 
-            "name": "GTF2GeneList", 
+            "label": "n_neighbors", 
+            "name": "Scanpy ParameterIterator", 
             "outputs": [
                 {
-                    "name": "feature_annotation", 
-                    "type": "tsv"
+                    "name": "parameter_iteration", 
+                    "type": "input"
                 }
             ], 
             "position": {
-                "left": 502, 
-                "top": 296
+                "left": 211, 
+                "top": 843
             }, 
             "post_job_actions": {
-                "HideDatasetActionfeature_annotation": {
+                "HideDatasetActionparameter_iteration": {
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
-                    "output_name": "feature_annotation"
+                    "output_name": "parameter_iteration"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2", 
             "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9", 
-                "name": "gtf2gene_list", 
+                "changeset_revision": "7c4d44c14ceb", 
+                "name": "scanpy_parameter_iterator", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"first_field\": \"\\\"gene_id\\\"\", \"feature_type\": \"\\\"gene\\\"\", \"fields\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"mito\": \"{\\\"__current_case__\\\": 0, \\\"mark_mito\\\": \\\"true\\\", \\\"mito_biotypes\\\": \\\"mt_trna,mt_rrna,mt_trna_pseudogene\\\", \\\"mito_chr\\\": \\\"mt,mitochondrion_genome,mito,m,chrM,chrMt\\\"}\", \"version_transcripts\": \"\\\"false\\\"\", \"cdnas\": \"{\\\"__current_case__\\\": 1, \\\"filter_cdnas\\\": \\\"false\\\"}\", \"noheader\": \"\\\"false\\\"\", \"gtf_input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
-            "tool_version": "1.42.1+galaxy4", 
+            "tool_state": "{\"__page__\": null, \"input_type\": \"{\\\"__current_case__\\\": 0, \\\"input_values\\\": \\\"3, 5, 10, 15, 20, 25, 30, 50, 100\\\", \\\"parameter_values\\\": \\\"list_comma_separated_values\\\"}\", \"__rerun_remap_job_id__\": null, \"parameter_name\": \"\\\"n_neighbors\\\"\"}", 
+            "tool_version": "0.0.1+galaxy2", 
             "type": "tool", 
-            "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
+            "uuid": "a9e2b9c4-7b48-4014-9006-e8c48faa41c5", 
             "workflow_outputs": []
         }, 
         "8": {
@@ -292,8 +287,52 @@
                 }
             ], 
             "position": {
-                "left": 502, 
-                "top": 433
+                "left": 513, 
+                "top": 227
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "feature_annotation"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9", 
+                "name": "gtf2gene_list", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"first_field\": \"\\\"gene_id\\\"\", \"feature_type\": \"\\\"gene\\\"\", \"fields\": \"\\\"\\\"\", \"__rerun_remap_job_id__\": null, \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"mito\": \"{\\\"__current_case__\\\": 0, \\\"mark_mito\\\": \\\"true\\\", \\\"mito_biotypes\\\": \\\"mt_trna,mt_rrna,mt_trna_pseudogene\\\", \\\"mito_chr\\\": \\\"mt,mitochondrion_genome,mito,m,chrM,chrMt\\\"}\", \"version_transcripts\": \"\\\"false\\\"\", \"cdnas\": \"{\\\"__current_case__\\\": 1, \\\"filter_cdnas\\\": \\\"false\\\"}\", \"noheader\": \"\\\"false\\\"\", \"gtf_input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_version": "1.42.1+galaxy4", 
+            "type": "tool", 
+            "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
+            "workflow_outputs": []
+        }, 
+        "9": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
+            "errors": null, 
+            "id": 9, 
+            "input_connections": {
+                "gtf_input": {
+                    "id": 5, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "GTF2GeneList", 
+            "outputs": [
+                {
+                    "name": "feature_annotation", 
+                    "type": "tsv"
+                }
+            ], 
+            "position": {
+                "left": 513, 
+                "top": 364
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -322,11 +361,11 @@
             "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19", 
             "workflow_outputs": []
         }, 
-        "9": {
+        "10": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 9, 
+            "id": 10, 
             "input_connections": {
                 "barcodes": {
                     "id": 3, 
@@ -337,7 +376,7 @@
                     "output_name": "output"
                 }, 
                 "gene_meta": {
-                    "id": 7, 
+                    "id": 8, 
                     "output_name": "feature_annotation"
                 }, 
                 "genes": {
@@ -349,28 +388,7 @@
                     "output_name": "output"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "gene_meta"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "genes"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "cell_meta"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "matrix"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x", 
-                    "name": "barcodes"
-                }
-            ], 
+            "inputs": [], 
             "label": null, 
             "name": "Scanpy Read10x", 
             "outputs": [
@@ -380,8 +398,8 @@
                 }
             ], 
             "position": {
-                "left": 830, 
-                "top": 296
+                "left": 841, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -404,7 +422,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"barcodes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
             "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
@@ -416,14 +434,14 @@
                 }
             ]
         }, 
-        "10": {
+        "11": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 10, 
+            "id": 11, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 9, 
+                    "id": 10, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -449,8 +467,8 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 296
+                "left": 1169, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -492,18 +510,18 @@
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
             "workflow_outputs": []
         }, 
-        "11": {
+        "12": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 11, 
+            "id": 12, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 10, 
+                    "id": 11, 
                     "output_name": "output_h5"
                 }, 
                 "subsets_0|subset": {
-                    "id": 8, 
+                    "id": 9, 
                     "output_name": "feature_annotation"
                 }
             }, 
@@ -529,8 +547,8 @@
                 }
             ], 
             "position": {
-                "left": 1486, 
-                "top": 296
+                "left": 1497, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -594,14 +612,14 @@
                 }
             ]
         }, 
-        "12": {
+        "13": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 12, 
+            "id": 13, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 11, 
+                    "id": 12, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -615,8 +633,8 @@
                 }
             ], 
             "position": {
-                "left": 1814, 
-                "top": 296
+                "left": 1825, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -664,14 +682,14 @@
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
             "workflow_outputs": []
         }, 
-        "13": {
+        "14": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
             "errors": null, 
-            "id": 13, 
+            "id": 14, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 11, 
+                    "id": 12, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -697,8 +715,8 @@
                 }
             ], 
             "position": {
-                "left": 1814, 
-                "top": 433
+                "left": 1825, 
+                "top": 364
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -762,14 +780,14 @@
                 }
             ]
         }, 
-        "14": {
+        "15": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy9", 
             "errors": null, 
-            "id": 14, 
+            "id": 15, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 12, 
+                    "id": 13, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -783,8 +801,8 @@
                 }
             ], 
             "position": {
-                "left": 2142, 
-                "top": 296
+                "left": 2153, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -811,14 +829,14 @@
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "15": {
+        "16": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
             "errors": null, 
-            "id": 15, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 14, 
+                    "id": 15, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -832,8 +850,8 @@
                 }
             ], 
             "position": {
-                "left": 2470, 
-                "top": 296
+                "left": 2481, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -860,14 +878,14 @@
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "16": {
+        "17": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 16, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -881,8 +899,8 @@
                 }
             ], 
             "position": {
-                "left": 2798, 
-                "top": 296
+                "left": 2809, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -909,14 +927,14 @@
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "17": {
+        "18": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 17, 
+            "id": 18, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5"
                 }, 
                 "settings|perplexity_file": {
@@ -938,8 +956,8 @@
                 }
             ], 
             "position": {
-                "left": 2798, 
-                "top": 433
+                "left": 2809, 
+                "top": 364
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -979,14 +997,14 @@
                 }
             ]
         }, 
-        "18": {
+        "19": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "errors": null, 
-            "id": 18, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1000,8 +1018,8 @@
                 }
             ], 
             "position": {
-                "left": 2798, 
-                "top": 688
+                "left": 2809, 
+                "top": 619
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1023,14 +1041,83 @@
             "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
             "workflow_outputs": []
         }, 
-        "19": {
+        "20": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy11", 
             "errors": null, 
-            "id": 19, 
+            "id": 20, 
             "input_connections": {
                 "input_obj_file": {
                     "id": 16, 
+                    "output_name": "output_h5"
+                }, 
+                "settings|n_neighbors_file": {
+                    "id": 7, 
+                    "output_name": "parameter_iteration"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph", 
+                    "name": "input_obj_file"
+                }, 
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph", 
+                    "name": "settings"
+                }
+            ], 
+            "label": "neighbours for umap", 
+            "name": "Scanpy ComputeGraph", 
+            "outputs": [
+                {
+                    "name": "output_h5", 
+                    "type": "h5"
+                }
+            ], 
+            "position": {
+                "left": 2809, 
+                "top": 756
+            }, 
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "output_h5"
+                }, 
+                "HideDatasetActionoutput_h5": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_h5"
+                }, 
+                "RenameDatasetActionoutput_h5": {
+                    "action_arguments": {
+                        "newname": "#{n_neighbors_file}"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "output_h5"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy11", 
+            "tool_shed_repository": {
+                "changeset_revision": "232937b5bb8f", 
+                "name": "scanpy_compute_graph", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"knn\\\": \\\"true\\\", \\\"method\\\": \\\"umap\\\", \\\"n_neighbors\\\": \\\"15\\\", \\\"n_neighbors_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"n_pcs\\\": \\\"50\\\", \\\"random_seed\\\": \\\"0\\\", \\\"use_rep\\\": \\\"X_pca\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__rerun_remap_job_id__\": null}", 
+            "tool_version": "1.4.3+galaxy11", 
+            "type": "tool", 
+            "uuid": "15106e26-8656-4fc9-ab08-c20a7bbb9e49", 
+            "workflow_outputs": []
+        }, 
+        "21": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
+            "errors": null, 
+            "id": 21, 
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 17, 
                     "output_name": "output_h5"
                 }, 
                 "settings|resolution_file": {
@@ -1052,8 +1139,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 296
+                "left": 3137, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1100,23 +1187,18 @@
                 }
             ]
         }, 
-        "20": {
+        "22": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 20, 
+            "id": 22, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 17, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_markers_cell_type", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1130,8 +1212,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 549
+                "left": 3137, 
+                "top": 482
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1159,7 +1241,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 
@@ -1171,14 +1253,14 @@
                 }
             ]
         }, 
-        "21": {
+        "23": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 21, 
+            "id": 23, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 20, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1196,8 +1278,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 736
+                "left": 3137, 
+                "top": 667
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1212,7 +1294,7 @@
                 }, 
                 "RenameDatasetActionoutput_embed": {
                     "action_arguments": {
-                        "newname": "umap_embedd.csv"
+                        "newname": "umap_#{input_obj_file}.tsv"
                     }, 
                     "action_type": "RenameDatasetAction", 
                     "output_name": "output_embed"
@@ -1225,7 +1307,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"alpha\\\": \\\"1.0\\\", \\\"default\\\": \\\"false\\\", \\\"gamma\\\": \\\"1.0\\\", \\\"init_pos\\\": \\\"spectral\\\", \\\"maxiter\\\": \\\"\\\", \\\"min_dist\\\": \\\"0.5\\\", \\\"n_components\\\": \\\"2\\\", \\\"negative_sample_rate\\\": \\\"5\\\", \\\"random_seed\\\": \\\"0\\\", \\\"spread\\\": \\\"1.0\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"key_added\": \"\\\"\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"use_graph\": \"\\\"neighbors\\\"\", \"__rerun_remap_job_id__\": null}", 
+            "tool_state": "{\"__page__\": null, \"embeddings\": \"\\\"true\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"alpha\\\": \\\"1.0\\\", \\\"default\\\": \\\"false\\\", \\\"gamma\\\": \\\"1.0\\\", \\\"init_pos\\\": \\\"spectral\\\", \\\"maxiter\\\": \\\"\\\", \\\"min_dist\\\": \\\"0.5\\\", \\\"n_components\\\": \\\"2\\\", \\\"negative_sample_rate\\\": \\\"5\\\", \\\"random_seed\\\": \\\"0\\\", \\\"spread\\\": \\\"1.0\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"key_added\": \"\\\"\\\"\", \"use_graph\": \"\\\"neighbors\\\"\", \"__rerun_remap_job_id__\": null}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "a84344e4-50c9-4a6b-bc20-faa056f39fed", 
@@ -1237,23 +1319,18 @@
                 }
             ]
         }, 
-        "22": {
+        "24": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "errors": null, 
-            "id": 22, 
+            "id": 24, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 19, 
+                    "id": 21, 
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1267,8 +1344,8 @@
                 }
             ], 
             "position": {
-                "left": 3454, 
-                "top": 296
+                "left": 3465, 
+                "top": 227
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1296,7 +1373,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
@@ -1307,53 +1384,9 @@
                     "uuid": "bd230278-9a3a-4b81-892f-8c0ffe707846"
                 }
             ]
-        }, 
-        "23": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
-            "errors": null, 
-            "id": 23, 
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 21, 
-                    "output_name": "output_h5"
-                }
-            }, 
-            "inputs": [], 
-            "label": "plot_umap", 
-            "name": "Scanpy PlotEmbed", 
-            "outputs": [
-                {
-                    "name": "output_png", 
-                    "type": "png"
-                }
-            ], 
-            "position": {
-                "left": 3454, 
-                "top": 484
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_png"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
-            "tool_shed_repository": {
-                "changeset_revision": "882f4671d686", 
-                "name": "scanpy_plot_embed", 
-                "owner": "ebi-gxa", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"legend_fontsize\": \"\\\"10\\\"\", \"point_size\": \"\\\"\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"basis\": \"\\\"umap\\\"\", \"__page__\": null, \"fig_fontsize\": \"\\\"10\\\"\", \"__rerun_remap_job_id__\": null, \"fig_frame\": \"\\\"false\\\"\", \"color_by\": \"\\\"n_genes\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fig_size\": \"\\\"7,7\\\"\", \"fig_dpi\": \"\\\"80\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"fig_title\": \"\\\"UMAP\\\"\", \"legend_loc\": \"\\\"right margin\\\"\", \"use_raw\": \"\\\"true\\\"\"}", 
-            "tool_version": "1.4.3+galaxy0", 
-            "type": "tool", 
-            "uuid": "cdc5e6b0-2808-430b-8468-ddb51f90b640", 
-            "workflow_outputs": []
         }
     }, 
     "tags": [], 
-    "uuid": "8a93451e-ecde-42fc-a401-d53d3378c8d6", 
-    "version": 3
+    "uuid": "e22f2f1f-6e97-472e-a38d-ab3060efc808", 
+    "version": 6
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 308
+                "top": 288
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "74619e35-1bde-421e-8463-39888902e2ac"
+                    "uuid": "ab6f0758-3cf8-4f87-a17e-b6f960d9c2fd"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 396
+                "top": 376
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "f28cd8a6-87d7-4bb8-9b1e-48595d5f78f6"
+                    "uuid": "f3e6ceb8-96bf-4847-b7a7-271e316aad09"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 484
+                "top": 464
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "598c7cd3-32bd-40dd-8cec-916833e38dd0"
+                    "uuid": "34a26f64-55df-492a-81ed-4f278499faca"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 572
+                "top": 552
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "b53c3b3a-e66b-4398-a720-ac542673ebfa"
+                    "uuid": "a545eb26-f6f8-4798-bc62-d112fbada810"
                 }
             ]
         }, 
@@ -173,7 +173,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 660
+                "top": 640
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -222,7 +222,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -266,7 +266,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 357
+                "top": 337
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -334,7 +334,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -345,7 +345,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "cf55e0e462da", 
+                "changeset_revision": "b021ae78ccb4", 
                 "name": "scanpy_read_10x", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -395,8 +395,8 @@
                 }
             ], 
             "position": {
-                "left": 1157, 
-                "top": 220
+                "left": 1158, 
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -436,7 +436,23 @@
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "matrix_10x", 
+                    "uuid": "e59e41fb-4cfa-4b6b-9af4-20d1c7db9ab7"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "barcodes_10x", 
+                    "uuid": "4f535420-61b3-4330-a8f5-76797e295618"
+                }, 
+                {
+                    "label": null, 
+                    "output_name": "genes_10x", 
+                    "uuid": "90e417e1-1d39-46dd-95f6-9b0406aa23c8"
+                }
+            ]
         }, 
         "10": {
             "annotation": "", 
@@ -476,7 +492,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -562,7 +578,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -644,7 +660,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 357
+                "top": 337
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -656,27 +672,6 @@
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
-                }, 
-                "RenameDatasetActionbarcodes_10x": {
-                    "action_arguments": {
-                        "newname": "filtered_normalised_barcodes.tsv"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "barcodes_10x"
-                }, 
-                "RenameDatasetActiongenes_10x": {
-                    "action_arguments": {
-                        "newname": "filtered_normalised_genes.tsv"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "genes_10x"
-                }, 
-                "RenameDatasetActionmatrix_10x": {
-                    "action_arguments": {
-                        "newname": "filtered_normalised_matrix.mtx"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "matrix_10x"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.4.3+galaxy3", 
@@ -686,7 +681,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"export_mtx\": \"\\\"true\\\"\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
+            "tool_state": "{\"export_mtx\": \"\\\"true\\\"\", \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
             "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "10db47e3-d803-43f6-99ba-b2c852774527", 
@@ -710,7 +705,7 @@
         }, 
         "13": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy9", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
             "errors": null, 
             "id": 13, 
             "input_connections": {
@@ -730,7 +725,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -744,22 +739,22 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy9", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "7a68f44c866b", 
+                "changeset_revision": "d88a29e2eba6", 
                 "name": "scanpy_find_variable_genes", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
-            "tool_version": "1.4.3+galaxy9", 
+            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
         "14": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
             "errors": null, 
             "id": 14, 
             "input_connections": {
@@ -768,12 +763,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunPCA", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "run_pca", 
             "name": "Scanpy RunPCA", 
             "outputs": [
@@ -784,7 +774,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -798,15 +788,15 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy10", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "2dd53b944e78", 
+                "changeset_revision": "fe900f147809", 
                 "name": "scanpy_run_pca", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
-            "tool_version": "1.4.3+galaxy10", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"extra_outputs\": \"null\", \"n_pcs\": \"\\\"50\\\"\", \"__rerun_remap_job_id__\": null, \"run_mode\": \"{\\\"__current_case__\\\": 1, \\\"chunked\\\": \\\"false\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"svd_solver\\\": \\\"arpack\\\", \\\"zero_center\\\": \\\"false\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
@@ -833,7 +823,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -849,7 +839,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "6b2673e1f4c6", 
+                "changeset_revision": "53e6944bd162", 
                 "name": "scanpy_compute_graph", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -890,7 +880,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 357
+                "top": 337
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -913,7 +903,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "3589dfaef3f6", 
+                "changeset_revision": "b946c0c60d4c", 
                 "name": "scanpy_run_tsne", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -952,7 +942,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 612
+                "top": 592
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -963,7 +953,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "882f4671d686", 
+                "changeset_revision": "ddb20964072e", 
                 "name": "scanpy_plot_embed", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1004,7 +994,7 @@
             ], 
             "position": {
                 "left": 3145, 
-                "top": 215
+                "top": 195
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1034,7 +1024,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "455846afcc73", 
+                "changeset_revision": "e232ea3fff07", 
                 "name": "scanpy_find_cluster", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1077,7 +1067,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 475
+                "top": 455
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1100,7 +1090,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "c111d7d04f0b", 
+                "changeset_revision": "01750c193a83", 
                 "name": "scanpy_run_umap", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1128,7 +1118,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1143,7 +1138,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 220
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1166,12 +1161,12 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "c18f446dcfbf", 
+                "changeset_revision": "af5e4efa9e66", 
                 "name": "scanpy_find_markers", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
@@ -1205,7 +1200,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 408
+                "top": 388
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1216,7 +1211,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "882f4671d686", 
+                "changeset_revision": "ddb20964072e", 
                 "name": "scanpy_plot_embed", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1229,6 +1224,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "a0eb168f-09b2-4995-aada-302dbeb80dca", 
-    "version": 1
+    "uuid": "5e1e355f-03b9-48f9-a9b4-cb8941ba4429", 
+    "version": 18
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 377
+                "top": 384
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "41a76a46-ecf4-49a2-a6c6-bcb8e60909af"
+                    "uuid": "cc26f133-27d8-4b39-8148-bfaacce60c58"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 465
+                "top": 472
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "57c9158c-2b9b-4b01-848b-ee138ef8bd8a"
+                    "uuid": "42750eea-2e3a-4429-9619-a2e4444e59d7"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 553
+                "top": 560
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "83718b22-8f16-4bfd-ac45-db723f089c93"
+                    "uuid": "206828d5-5de8-42cd-b642-cb4a82d73a33"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 641
+                "top": 648
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "48be6401-93e1-4f91-a8d5-e51c2104a757"
+                    "uuid": "1a69a544-445c-49b5-ab25-b4df89383832"
                 }
             ]
         }, 
@@ -168,7 +168,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 729
+                "top": 736
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -179,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "3ac2d603-34d1-49a8-9a99-38469f679743"
+                    "uuid": "8ac66b0b-13b1-4f0d-95f1-780a301f5707"
                 }
             ]
         }, 
@@ -200,7 +200,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 817
+                "top": 824
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -249,7 +249,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -293,7 +293,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 426
+                "top": 433
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -349,7 +349,28 @@
                     "output_name": "output"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "gene_meta"
+                }, 
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "genes"
+                }, 
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "cell_meta"
+                }, 
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "matrix"
+                }, 
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x", 
+                    "name": "barcodes"
+                }
+            ], 
             "label": null, 
             "name": "Scanpy Read10x", 
             "outputs": [
@@ -360,12 +381,19 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
                     "action_arguments": {}, 
                     "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "output_h5"
+                }, 
+                "RenameDatasetActionoutput_h5": {
+                    "action_arguments": {
+                        "newname": "raw.h5"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
                     "output_name": "output_h5"
                 }
             }, 
@@ -376,7 +404,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"barcodes\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
+            "tool_state": "{\"gene_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": null, \"genes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"cell_meta\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"var_names\": \"\\\"gene_ids\\\"\", \"barcodes\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__rerun_remap_job_id__\": null, \"matrix\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
             "tool_version": "1.4.3+galaxy0", 
             "type": "tool", 
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
@@ -422,7 +450,7 @@
             ], 
             "position": {
                 "left": 1158, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -502,7 +530,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -588,7 +616,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -670,7 +698,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 426
+                "top": 433
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -756,7 +784,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -805,7 +833,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -854,7 +882,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -906,12 +934,12 @@
                 }, 
                 {
                     "name": "output_embed", 
-                    "type": "tsv"
+                    "type": "csv"
                 }
             ], 
             "position": {
                 "left": 2798, 
-                "top": 426
+                "top": 433
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -973,7 +1001,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 681
+                "top": 688
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1025,7 +1053,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1083,7 +1111,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "find_markers_cell_type", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1092,13 +1125,13 @@
                     "type": "h5"
                 }, 
                 {
-                    "name": "output_tsv", 
-                    "type": "tsv"
+                    "name": "output_csv", 
+                    "type": "csv"
                 }
             ], 
             "position": {
                 "left": 3126, 
-                "top": 542
+                "top": 549
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1111,12 +1144,12 @@
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
                 }, 
-                "RenameDatasetActionoutput_tsv": {
+                "RenameDatasetActionoutput_csv": {
                     "action_arguments": {
                         "newname": "celltype_markers.csv"
                     }, 
                     "action_type": "RenameDatasetAction", 
-                    "output_name": "output_tsv"
+                    "output_name": "output_csv"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
@@ -1126,15 +1159,15 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"inferred_cell_type\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 
             "workflow_outputs": [
                 {
                     "label": null, 
-                    "output_name": "output_tsv", 
-                    "uuid": "e78b83f6-5d7b-44f9-aeb2-f20a059bdd32"
+                    "output_name": "output_csv", 
+                    "uuid": "3478165f-c365-442c-ac13-3a2bc287e7d0"
                 }
             ]
         }, 
@@ -1164,7 +1197,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 729
+                "top": 736
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1215,7 +1248,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "find_markers", 
             "name": "Scanpy FindMarkers", 
             "outputs": [
@@ -1224,13 +1262,13 @@
                     "type": "h5"
                 }, 
                 {
-                    "name": "output_tsv", 
-                    "type": "tsv"
+                    "name": "output_csv", 
+                    "type": "csv"
                 }
             ], 
             "position": {
                 "left": 3454, 
-                "top": 289
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1243,12 +1281,12 @@
                     "action_type": "HideDatasetAction", 
                     "output_name": "output_h5"
                 }, 
-                "RenameDatasetActionoutput_tsv": {
+                "RenameDatasetActionoutput_csv": {
                     "action_arguments": {
                         "newname": "markers_#{input_obj_file}.csv"
                     }, 
                     "action_type": "RenameDatasetAction", 
-                    "output_name": "output_tsv"
+                    "output_name": "output_csv"
                 }
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
@@ -1258,15 +1296,15 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.4.3+galaxy1", 
             "type": "tool", 
             "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
             "workflow_outputs": [
                 {
                     "label": null, 
-                    "output_name": "output_tsv", 
-                    "uuid": "af32de20-9cf0-4d3a-8c0d-f8ce794a96cb"
+                    "output_name": "output_csv", 
+                    "uuid": "bd230278-9a3a-4b81-892f-8c0ffe707846"
                 }
             ]
         }, 
@@ -1292,7 +1330,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 477
+                "top": 484
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1316,6 +1354,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "865f5cbb-3c68-48c2-beff-7bcc66c2c167", 
-    "version": 2
+    "uuid": "8a93451e-ecde-42fc-a401-d53d3378c8d6", 
+    "version": 3
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -21,7 +21,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -60,7 +60,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 303
+                "top": 308
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,7 +71,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "e797b05d-35c2-4d4b-b03d-9529ee07dfd5"
+                    "uuid": "4ba5c5bc-73fc-43b5-a5b8-62f7b7b23c4e"
                 }
             ]
         }, 
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 391
+                "top": 396
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1ce6f4d9-0f55-4753-b643-fe5be0ff0fdb"
+                    "uuid": "01487010-5d0d-4b9b-ae3d-f3b14b5c678f"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 479
+                "top": 484
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "8dff8582-1141-4d5b-89d6-19590106c654"
+                    "uuid": "d9a50636-f6e9-4a98-a545-99d562b5dda3"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 567
+                "top": 572
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "75f5d65d-0121-4438-8af9-05256cfb2ecc"
+                    "uuid": "9be8fcb4-9584-44e4-9557-555b85cf5166"
                 }
             ]
         }, 
@@ -173,7 +173,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 655
+                "top": 660
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -222,7 +222,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -266,7 +266,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 352
+                "top": 357
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -334,7 +334,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -345,7 +345,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "b021ae78ccb4", 
+                "changeset_revision": "cf55e0e462da", 
                 "name": "scanpy_read_10x", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -396,7 +396,7 @@
             ], 
             "position": {
                 "left": 1157, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -476,7 +476,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -562,7 +562,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -621,12 +621,7 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy NormaliseData", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "normalise_data", 
             "name": "Scanpy NormaliseData", 
             "outputs": [
@@ -649,7 +644,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 352
+                "top": 357
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -691,7 +686,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"export_mtx\": \"\\\"true\\\"\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"scale_factor\": \"\\\"1000000.0\\\"\", \"input_format\": \"\\\"anndata\\\"\", \"save_raw\": \"\\\"true\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"export_mtx\": \"\\\"true\\\"\", \"fraction\": \"\\\"1.0\\\"\", \"__rerun_remap_job_id__\": null, \"log_transform\": \"\\\"false\\\"\"}", 
             "tool_version": "1.4.3+galaxy3", 
             "type": "tool", 
             "uuid": "10db47e3-d803-43f6-99ba-b2c852774527", 
@@ -724,7 +719,12 @@
                     "output_name": "output_h5"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindVariableGenes", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "find_variable_genes", 
             "name": "Scanpy FindVariableGenes", 
             "outputs": [
@@ -735,7 +735,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -751,13 +751,13 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "d88a29e2eba6", 
+                "changeset_revision": "7a68f44c866b", 
                 "name": "scanpy_find_variable_genes", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"input_format\": \"\\\"anndata\\\"\", \"__page__\": null, \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
-            "tool_version": "1.4.3+galaxy0", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata\\\"\", \"filter\": \"\\\"false\\\"\", \"n_bin\": \"\\\"20\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"{\\\"__current_case__\\\": 0, \\\"flavor\\\": \\\"seurat\\\", \\\"max_disp\\\": \\\"1000000000.0\\\", \\\"max_mean\\\": \\\"1000000000.0\\\", \\\"min_disp\\\": \\\"0.5\\\", \\\"min_mean\\\": \\\"0.0125\\\"}\"}", 
+            "tool_version": "1.4.3+galaxy9", 
             "type": "tool", 
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
@@ -784,7 +784,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -800,7 +800,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "fe900f147809", 
+                "changeset_revision": "8b4dae3748d3", 
                 "name": "scanpy_run_pca", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -833,7 +833,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -849,7 +849,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "53e6944bd162", 
+                "changeset_revision": "6b2673e1f4c6", 
                 "name": "scanpy_compute_graph", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -890,7 +890,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 352
+                "top": 357
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -913,7 +913,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "b946c0c60d4c", 
+                "changeset_revision": "3589dfaef3f6", 
                 "name": "scanpy_run_tsne", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -952,7 +952,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 607
+                "top": 612
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -963,7 +963,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "ddb20964072e", 
+                "changeset_revision": "882f4671d686", 
                 "name": "scanpy_plot_embed", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1004,7 +1004,7 @@
             ], 
             "position": {
                 "left": 3145, 
-                "top": 210
+                "top": 215
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1034,7 +1034,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "e232ea3fff07", 
+                "changeset_revision": "455846afcc73", 
                 "name": "scanpy_find_cluster", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1077,7 +1077,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 470
+                "top": 475
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1100,7 +1100,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "01750c193a83", 
+                "changeset_revision": "c111d7d04f0b", 
                 "name": "scanpy_run_umap", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1143,7 +1143,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 215
+                "top": 220
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1166,7 +1166,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.4.3+galaxy1", 
             "tool_shed_repository": {
-                "changeset_revision": "af5e4efa9e66", 
+                "changeset_revision": "c18f446dcfbf", 
                 "name": "scanpy_find_markers", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1205,7 +1205,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 403
+                "top": 408
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1216,7 +1216,7 @@
             }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.4.3+galaxy0", 
             "tool_shed_repository": {
-                "changeset_revision": "ddb20964072e", 
+                "changeset_revision": "882f4671d686", 
                 "name": "scanpy_plot_embed", 
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1229,6 +1229,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "1bdbfa5d-6ec1-4ce7-8d26-2b7bac7ae68c", 
-    "version": 20
+    "uuid": "d5685fb9-ed12-4f69-bab6-f687104a4a2c", 
+    "version": 2
 }

--- a/w_smart-seq_clustering/setup.sh
+++ b/w_smart-seq_clustering/setup.sh
@@ -16,8 +16,8 @@ fi
 
 [ -z ${matrix_file+x} ] && echo "Env var matrix_file should be set." && exit 1
 [ -z ${genes_file+x} ] && echo "Env var genes_file should be set." && exit 1
-[ -z ${barcodes_file+x} ] && echo "env var barcodes_file should be set." && exit 1
-[ -z ${cell_meta_file+x} ] && echo "env var cell_meta_file should be set." && exit 1
+[ -z ${barcodes_file+x} ] && echo "Env var barcodes_file should be set." && exit 1
+[ -z ${cell_meta_file+x} ] && echo "Env var cell_meta_file should be set." && exit 1
 [ -z ${gtf_file+x} ] && echo "Env var gtf_file should be set." && exit 1
 [ -z ${EXP_ID+x} ] && echo "Env var EXP_ID should be set." && exit 1
 

--- a/w_smart-seq_clustering/setup.sh
+++ b/w_smart-seq_clustering/setup.sh
@@ -16,7 +16,8 @@ fi
 
 [ -z ${matrix_file+x} ] && echo "Env var matrix_file should be set." && exit 1
 [ -z ${genes_file+x} ] && echo "Env var genes_file should be set." && exit 1
-[ -z ${barcodes_file+x} ] && echo "Env var barcodes_file should be set." && exit 1
+[ -z ${barcodes_file+x} ] && echo "env var barcodes_file should be set." && exit 1
+[ -z ${cell_meta_file+x} ] && echo "env var cell_meta_file should be set." && exit 1
 [ -z ${gtf_file+x} ] && echo "Env var gtf_file should be set." && exit 1
 [ -z ${EXP_ID+x} ] && echo "Env var EXP_ID should be set." && exit 1
 
@@ -25,6 +26,7 @@ inputs_yaml=$WORKDIR/scanpy_clustering_inputs_$EXP_ID\.yaml
 sed "s+<MATRIX_PATH>+$matrix_file+" $scriptDir/scanpy_clustering_inputs.yaml.template | \
     sed "s+<GENES_PATH>+$genes_file+" | \
     sed "s+<BARCODES_PATH>+$barcodes_file+" | \
+    sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
     sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml
 
 echo "export inputs_yaml=$inputs_yaml" > $envs_for_workflow_run


### PR DESCRIPTION
This PR contains workflow modifications required for cell type differential analysis. The Galaxy clustering workflow itself has been altered, but also bundling etc, via separate PRs on the submodule repos. 

See also:
 - https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/12.
 - https://github.com/ebi-gene-expression-group/scxa-bundle-workflow/pull/6

Changes here:

 - Correct file names to tsvs now output by scanpy-scripts
 - Change clustering workflow to run parameterised umaps as well as tsnes (see http://galaxy-gxa-001:8089/u/jmanning/w/scanpy-prod-143-smart-with-cell-type-differential-imported-from-uploaded-file-2)
 - Parse cell type metadata to allow...
 - addition of cell type marker generation step 