### PR TITLE
Feature/marker groupby from file

### DIFF
--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -59,18 +59,29 @@ inputs_yaml=$WORKDIR/scanpy_clustering_inputs_$EXP_ID\.yaml
 parameters_yaml=$WORKDIR/scanpy_clustering_parameters_$EXP_ID\.yaml
 flavor_dir=$baseDir/$FLAVOUR
 
+# Store the metadata variables we want to group by to a file. Right now this is
+# only cell type, but will likely include other things in future. The dummpy
+# CELL_TYPE_FIELD value will cause that instance of marker detection to fail in
+# the workflow, but the failure will be filtered out.
+
+meta_vars_file='meta_vars.txt'
+if [ -z "$cell_type_field" ]; then
+    cell_type_field=CELL_TYPE_FIELD    
+fi
+echo -e "$cell_type_field" > $meta_vars_file
+
+# Run substitutions on the inputs template
+
 sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.template | \
     sed "s+<GENES_PATH>+$genes_file+" | \
     sed "s+<BARCODES_PATH>+$barcodes_file+" | \
     sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
-    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml
+    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml \
+    sed "s+<METADATA_VARS_PATH>+$meta_vars_file+" > $inputs_yaml
 
 # Make any required parameter tweaks
 
 cp $flavor_dir/scanpy_clustering_workflow_parameters.yaml $parameters_yaml
-if [ -n "$cell_type_field" ]; then
-    sed -i "s/CELL_TYPE_FIELD/$cell_type_field/" $parameters_yaml 
-fi
 
 # If the batch variable is set, then tell the workflow about it. Otherwise just
 # unset it so any batch-adjustment steps just 'pass through'.

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -76,7 +76,7 @@ sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.te
     sed "s+<GENES_PATH>+$genes_file+" | \
     sed "s+<BARCODES_PATH>+$barcodes_file+" | \
     sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
-    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml \
+    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml | \
     sed "s+<METADATA_VARS_PATH>+$meta_vars_file+" > $inputs_yaml
 
 # Make any required parameter tweaks

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -76,7 +76,7 @@ sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.te
     sed "s+<GENES_PATH>+$genes_file+" | \
     sed "s+<BARCODES_PATH>+$barcodes_file+" | \
     sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
-    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml | \
+    sed "s+<GTF_PATH>+$gtf_file+" | \
     sed "s+<METADATA_VARS_PATH>+$meta_vars_file+" > $inputs_yaml
 
 # Make any required parameter tweaks

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -76,8 +76,11 @@ sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.te
     sed "s+<GENES_PATH>+$genes_file+" | \
     sed "s+<BARCODES_PATH>+$barcodes_file+" | \
     sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
-    sed "s+<GTF_PATH>+$gtf_file+" | \
-    sed "s+<METADATA_VARS_PATH>+$meta_vars_file+" > $inputs_yaml
+    sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml
+
+if [ -n "$cell_type_field" ]; then
+    sed -i "s/CELL_TYPE_FIELD/$cell_type_field/" $parameters_yaml 
+fi
 
 # Make any required parameter tweaks
 

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -67,13 +67,12 @@ sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.te
     sed "s+<CELL_META_PATH>+$cell_meta_file+" | \
     sed "s+<GTF_PATH>+$gtf_file+" > $inputs_yaml
 
-if [ -n "$cell_type_field" ]; then
-    sed -i "s/CELL_TYPE_FIELD/$cell_type_field/" $parameters_yaml 
-fi
-
 # Make any required parameter tweaks
 
 cp $flavor_dir/scanpy_clustering_workflow_parameters.yaml $parameters_yaml
+if [ -n "$cell_type_field" ]; then
+    sed -i "s/CELL_TYPE_FIELD/$cell_type_field/" $parameters_yaml 
+fi
 
 # If the batch variable is set, then tell the workflow about it. Otherwise just
 # unset it so any batch-adjustment steps just 'pass through'.

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -59,17 +59,6 @@ inputs_yaml=$WORKDIR/scanpy_clustering_inputs_$EXP_ID\.yaml
 parameters_yaml=$WORKDIR/scanpy_clustering_parameters_$EXP_ID\.yaml
 flavor_dir=$baseDir/$FLAVOUR
 
-# Store the metadata variables we want to group by to a file. Right now this is
-# only cell type, but will likely include other things in future. The dummpy
-# CELL_TYPE_FIELD value will cause that instance of marker detection to fail in
-# the workflow, but the failure will be filtered out.
-
-meta_vars_file='meta_vars.txt'
-if [ -z "$cell_type_field" ]; then
-    cell_type_field=CELL_TYPE_FIELD    
-fi
-echo -e "$cell_type_field" > $meta_vars_file
-
 # Run substitutions on the inputs template
 
 sed "s+<MATRIX_PATH>+$matrix_file+" $flavor_dir/scanpy_clustering_inputs.yaml.template | \

--- a/util/choose_resolution_per_clustering.py
+++ b/util/choose_resolution_per_clustering.py
@@ -66,7 +66,7 @@ def main():
                 cluster_assignment[cell] = cluster_num
             cells_clusters[clusters] = cluster_assignment
 
-            source = args.clusters_path+"/markers_louvain_resolution_"+str(resolution)+".tsv"
+            source = args.clusters_path+"/markers_resolution_"+str(resolution)+".tsv"
             dest = args.output_dir+"/markers_"+str(clusters)+".tsv"
             if path.isfile(source):
                 shutil.copy(source, dest)

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -160,7 +160,12 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
-metadata_group_vars: {}
+meta_vars:
+    input_type:
+        __current_case__: 0
+        input_values: CELL_TYPE_FIELD
+        parameter_values: list_comma_separated_values
+    parameter_name: meta
 n_neighbors:
     input_type:
         __current_case__: 0
@@ -319,21 +324,3 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
-split_metadata_vars:
-    split_parms:
-        __current_case__: 6
-        input:
-            __class__: ConnectedValue
-        newfilenames: meta_var_
-        select_allocate:
-            __current_case__: 2
-            allocate: byrow
-        select_ftype: generic
-        select_mode:
-            __current_case__: 0
-            chunksize: '1'
-            mode: chunk
-        split_method:
-            __current_case__: 1
-            record_length: '1'
-            select_split_method: number

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -95,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_VARIABLE
+    batch_key: BATCH_FIELD
     input_format: anndata
     output_format: anndata_h5ad
     settings:

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -323,7 +323,7 @@ split_metadata_vars:
     split_parms:
         __current_case__: 6
         input:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         newfilenames: meta_var_
         select_allocate:
             __current_case__: 2

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -324,7 +324,7 @@ split_metadata_vars:
         __current_case__: 6
         input:
             __class__: RuntimeValue
-        newfilenames: split_file
+        newfilenames: meta_var_
         select_allocate:
             __current_case__: 2
             allocate: byrow

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -95,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_FIELD
+    batch_key: BATCH_VARIABLE
     input_format: anndata
     output_format: anndata_h5ad
     settings:
@@ -160,6 +160,7 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
+metadata_group_vars: {}
 n_neighbors:
     input_type:
         __current_case__: 0
@@ -318,11 +319,21 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
-specify_celltype_field:
-    token_set:
-    -   __index__: 0
-        line: CELL_TYPE_FIELD
-        repeat_select:
+split_metadata_vars:
+    split_parms:
+        __current_case__: 6
+        input:
+            __class__: RuntimeValue
+        newfilenames: split_file
+        select_allocate:
+            __current_case__: 2
+            allocate: byrow
+        select_ftype: generic
+        select_mode:
             __current_case__: 0
-            repeat_select_opts: user
-            times: '1'
+            chunksize: '1'
+            mode: chunk
+        split_method:
+            __current_case__: 1
+            record_length: '1'
+            select_split_method: number

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -1,7 +1,11 @@
-Filtered cell type marker: {}
-Filtered cluster markers: {}
+Filtered cellgroup markers: {}
 barcodes: {}
 cellmeta: {}
+clusering_slotnames:
+    replacements:
+    -   __index__: 0
+        find_pattern: (.*)
+        replace_pattern: louvain_resolution_\1
 filter_cells:
     categories: []
     export_mtx: 'true'
@@ -50,31 +54,11 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
     groupby: INPUT_OBJ
-    input_format: anndata
-    n_genes: '100'
-    output_format: anndata_h5ad
-    output_markers: 'true'
-    settings:
-        __current_case__: 1
-        default: 'false'
-        groups: ''
-        key_added: markers_GROUPBY
-        max_out_group_fraction: '1.0'
-        method: t-test_overestim_var
-        min_fold_change: '1.0'
-        min_in_group_fraction: '0.0'
-        pts: 'false'
-        rankby_abs: 'false'
-        reference: rest
-        tie_correct: 'false'
-        use_raw: 'true'
-find_markers_cell_type:
-    groupby: CELL_TYPE_FIELD
     input_format: anndata
     n_genes: '100'
     output_format: anndata_h5ad
@@ -111,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_FIELD
+    batch_key: BATCH_VARIABLE
     input_format: anndata
     output_format: anndata_h5ad
     settings:
@@ -152,7 +136,7 @@ make_project_file:
     sanitize_varm: 'false'
     top_genes: '50'
 matrix: {}
-merged_embeddings:
+merge_group_slotnames:
     advanced:
         conflict:
             __current_case__: 3
@@ -164,7 +148,7 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
-merged_markers:
+merged_embeddings:
     advanced:
         conflict:
             __current_case__: 3
@@ -334,3 +318,11 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
+specify_celltype_field:
+    token_set:
+    -   __index__: 0
+        line: CELL_TYPE_FIELD
+        repeat_select:
+            __current_case__: 0
+            repeat_select_opts: user
+            times: '1'

--- a/w_smart-seq_clustering/scanpy_clustering_allowed_errors.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_allowed_errors.yaml
@@ -2,5 +2,3 @@ find_clusters:
   - any
 find_markers:
   - any
-find_markers_cell_type:
-  - any

--- a/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
+++ b/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
@@ -13,6 +13,3 @@ cellmeta:
 gtf:
   path: <GTF_PATH>
   type: gtf
-metadata_group_vars:
-  path: <METADATA_VARS_PATH>
-  type: txt

--- a/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
+++ b/w_smart-seq_clustering/scanpy_clustering_inputs.yaml.template
@@ -13,3 +13,6 @@ cellmeta:
 gtf:
   path: <GTF_PATH>
   type: gtf
+metadata_group_vars:
+  path: <METADATA_VARS_PATH>
+  type: txt

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -16,7 +16,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 200
+                "top": 213
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -27,7 +27,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "98cfaf72-d48e-4834-b494-51c7720ff5a7"
+                    "uuid": "88a20170-58f4-49a1-b8d3-3ea6c982036f"
                 }
             ]
         }, 
@@ -48,7 +48,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 325
+                "top": 338
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 413
+                "top": 426
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "65854bbc-3644-401b-8d6f-2fc2f11108d1"
+                    "uuid": "1579ec06-58f6-4a54-80d2-a4ff076492d7"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 501
+                "top": 514
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "9be76aff-cfda-4e8f-9731-99de268e7fd1"
+                    "uuid": "fa8b08ec-830e-4063-8f14-b7fbc422df62"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 589
+                "top": 602
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "876e6abb-133a-4bd8-be7f-a03d7fabdf40"
+                    "uuid": "6df029e6-a8ce-4d05-a134-772b5d0a93ef"
                 }
             ]
         }, 
@@ -168,7 +168,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 677
+                "top": 690
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -179,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "13d53cb8-9bd9-4dec-b037-7366baedff31"
+                    "uuid": "4eed3998-6d91-4f68-a73a-7e02f4299f19"
                 }
             ]
         }, 
@@ -195,7 +195,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 765
+                "top": 778
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -206,7 +206,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "316436c3-cc82-4fe7-93d8-d135b0205476"
+                    "uuid": "d33b3e73-2f7c-428b-81ef-52f4c746f535"
                 }
             ]
         }, 
@@ -227,7 +227,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 853
+                "top": 866
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -271,7 +271,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 941
+                "top": 954
             }, 
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -320,7 +320,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 357
+                "top": 370
             }, 
             "post_job_actions": {
                 "HideDatasetActionlist_output_generic": {
@@ -336,7 +336,7 @@
                 "owner": "bgruening", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"newfilenames\\\": \\\"split_file\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"newfilenames\\\": \\\"meta_var_\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
             "tool_version": "0.4.0", 
             "type": "tool", 
             "uuid": "7950e4b1-e497-4365-a46b-833d64ab5ab1", 
@@ -364,7 +364,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 475
+                "top": 488
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -408,7 +408,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 612
+                "top": 625
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -459,7 +459,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -519,7 +519,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 385
+                "top": 398
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -579,7 +579,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -629,7 +629,7 @@
             ], 
             "position": {
                 "left": 1158, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -709,7 +709,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -795,7 +795,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -856,7 +856,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 356
+                "top": 369
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -942,7 +942,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -991,7 +991,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1029,7 +1029,12 @@
                     "output_name": "output_h5ad"
                 }
             }, 
-            "inputs": [], 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy Harmony", 
+                    "name": "input_obj_file"
+                }
+            ], 
             "label": "harmony_batch", 
             "name": "Scanpy Harmony", 
             "outputs": [
@@ -1040,7 +1045,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1056,7 +1061,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_VARIABLE\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
             "tool_version": "1.6.0+galaxy1", 
             "type": "tool", 
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 
@@ -1089,7 +1094,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1141,7 +1146,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 423
+                "top": 436
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1205,7 +1210,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 697
+                "top": 710
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1253,7 +1258,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 853
+                "top": 866
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1304,7 +1309,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {}, 
             "tool_id": "__BUILD_LIST__", 
@@ -1350,7 +1355,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 318
+                "top": 331
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1418,7 +1423,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 592
+                "top": 605
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1484,7 +1489,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {}, 
             "tool_id": "__MERGE_COLLECTION__", 
@@ -1526,7 +1531,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 385
+                "top": 398
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1578,7 +1583,7 @@
             ], 
             "position": {
                 "left": 4101, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1635,7 +1640,7 @@
             ], 
             "position": {
                 "left": 4429, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1690,7 +1695,7 @@
             ], 
             "position": {
                 "left": 4757, 
-                "top": 200
+                "top": 213
             }, 
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -1722,6 +1727,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "d1ac860e-82d6-4f20-ac3a-27385bf43515", 
-    "version": 7
+    "uuid": "2a787093-37b7-4f44-9524-12b1008f5072", 
+    "version": 9
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -1062,7 +1062,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_VARIABLE\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
             "tool_version": "1.6.0+galaxy1", 
             "type": "tool", 
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -6,42 +6,30 @@
     "steps": {
         "0": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0", 
+            "content_id": null, 
             "errors": null, 
             "id": 0, 
             "input_connections": {}, 
             "inputs": [], 
-            "label": "specify_celltype_field", 
-            "name": "Create text file", 
-            "outputs": [
-                {
-                    "name": "outfile", 
-                    "type": "txt"
-                }
-            ], 
+            "label": "metadata_group_vars", 
+            "name": "Input dataset", 
+            "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 252
+                "top": 200
             }, 
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "outfile"
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "2caa8b9e-85d0-4280-8c7c-fa513bc03a53", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "98cfaf72-d48e-4834-b494-51c7720ff5a7"
                 }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295", 
-                "name": "text_processing", 
-                "owner": "bgruening", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"token_set\": \"[{\\\"__index__\\\": 0, \\\"line\\\": \\\"CELL_TYPE_FIELD\\\", \\\"repeat_select\\\": {\\\"__current_case__\\\": 0, \\\"repeat_select_opts\\\": \\\"user\\\", \\\"times\\\": \\\"1\\\"}}]\"}", 
-            "tool_version": "1.1.0", 
-            "type": "tool", 
-            "uuid": "2cb41742-cc7b-4313-bdb2-ff2d37481d1c", 
-            "workflow_outputs": []
+            ]
         }, 
         "1": {
             "annotation": "", 
@@ -60,7 +48,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 377
+                "top": 325
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -99,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 465
+                "top": 413
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -110,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "2f273af5-c7d9-4f38-a50e-d3ab33713f3e"
+                    "uuid": "65854bbc-3644-401b-8d6f-2fc2f11108d1"
                 }
             ]
         }, 
@@ -126,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 553
+                "top": 501
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -137,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "96279f0a-ec3f-4235-9457-eb78347a4b64"
+                    "uuid": "9be76aff-cfda-4e8f-9731-99de268e7fd1"
                 }
             ]
         }, 
@@ -153,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 641
+                "top": 589
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -164,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "8629fa9e-d1b0-4e86-89f7-90bf2205e172"
+                    "uuid": "876e6abb-133a-4bd8-be7f-a03d7fabdf40"
                 }
             ]
         }, 
@@ -180,7 +168,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 729
+                "top": 677
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -191,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "277451dd-1e96-46f2-87d9-ff92a0e746af"
+                    "uuid": "13d53cb8-9bd9-4dec-b037-7366baedff31"
                 }
             ]
         }, 
@@ -207,7 +195,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 817
+                "top": 765
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -218,7 +206,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "51f2609f-b445-420c-81ca-5558a3c78335"
+                    "uuid": "316436c3-cc82-4fe7-93d8-d135b0205476"
                 }
             ]
         }, 
@@ -239,7 +227,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 905
+                "top": 853
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -283,7 +271,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 993
+                "top": 941
             }, 
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -307,40 +295,51 @@
         }, 
         "9": {
             "annotation": "", 
-            "content_id": "__BUILD_LIST__", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.4.0", 
             "errors": null, 
             "id": 9, 
             "input_connections": {
-                "datasets_0|input": {
+                "split_parms|input": {
                     "id": 0, 
-                    "output_name": "outfile"
+                    "output_name": "output"
                 }
             }, 
-            "inputs": [], 
-            "label": null, 
-            "name": "Build List", 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Split file", 
+                    "name": "split_parms"
+                }
+            ], 
+            "label": "split_metadata_vars", 
+            "name": "Split file", 
             "outputs": [
                 {
-                    "name": "output", 
+                    "name": "list_output_generic", 
                     "type": "input"
                 }
             ], 
             "position": {
                 "left": 502, 
-                "top": 252
+                "top": 357
             }, 
             "post_job_actions": {
-                "HideDatasetActionoutput": {
+                "HideDatasetActionlist_output_generic": {
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
-                    "output_name": "output"
+                    "output_name": "list_output_generic"
                 }
             }, 
-            "tool_id": "__BUILD_LIST__", 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"datasets\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\"}", 
-            "tool_version": "1.0.0", 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.4.0", 
+            "tool_shed_repository": {
+                "changeset_revision": "e77b954f0da5", 
+                "name": "split_file_to_collection", 
+                "owner": "bgruening", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"newfilenames\\\": \\\"split_file\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
+            "tool_version": "0.4.0", 
             "type": "tool", 
-            "uuid": "6d861117-7b6a-4bf8-be1c-47d0e6a54644", 
+            "uuid": "7950e4b1-e497-4365-a46b-833d64ab5ab1", 
             "workflow_outputs": []
         }, 
         "10": {
@@ -365,7 +364,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 489
+                "top": 475
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -409,7 +408,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 626
+                "top": 612
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -449,12 +448,7 @@
                     "output_name": "parameter_iteration"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Replace Text", 
-                    "name": "infile"
-                }
-            ], 
+            "inputs": [], 
             "label": "clusering_slotnames", 
             "name": "Replace Text", 
             "outputs": [
@@ -465,7 +459,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 369
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -481,7 +475,7 @@
                 "owner": "bgruening", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"replacements\": \"[{\\\"__index__\\\": 0, \\\"find_pattern\\\": \\\"(.*)\\\", \\\"replace_pattern\\\": \\\"louvain_resolution_\\\\\\\\1\\\"}]\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"replacements\": \"[{\\\"__index__\\\": 0, \\\"find_pattern\\\": \\\"(.*)\\\", \\\"replace_pattern\\\": \\\"louvain_resolution_\\\\\\\\1\\\"}]\", \"infile\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\"}", 
             "tool_version": "1.1.2", 
             "type": "tool", 
             "uuid": "fab045e5-d7bf-41eb-bbdf-76d5bc6c3a48", 
@@ -525,7 +519,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 437
+                "top": 385
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -571,7 +565,7 @@
                 }, 
                 "inputs_1|input": {
                     "id": 9, 
-                    "output_name": "output"
+                    "output_name": "list_output_generic"
                 }
             }, 
             "inputs": [], 
@@ -585,7 +579,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -635,7 +629,7 @@
             ], 
             "position": {
                 "left": 1158, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -715,7 +709,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -801,7 +795,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -862,7 +856,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 408
+                "top": 356
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -948,7 +942,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -997,7 +991,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1046,7 +1040,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1062,7 +1056,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_VARIABLE\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
             "tool_version": "1.6.0+galaxy1", 
             "type": "tool", 
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 
@@ -1095,7 +1089,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1147,7 +1141,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 475
+                "top": 423
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1211,7 +1205,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 749
+                "top": 697
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1259,7 +1253,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 905
+                "top": 853
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1310,7 +1304,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {}, 
             "tool_id": "__BUILD_LIST__", 
@@ -1356,7 +1350,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 370
+                "top": 318
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1424,7 +1418,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 644
+                "top": 592
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1490,7 +1484,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {}, 
             "tool_id": "__MERGE_COLLECTION__", 
@@ -1532,7 +1526,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 437
+                "top": 385
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1584,7 +1578,7 @@
             ], 
             "position": {
                 "left": 4101, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1641,7 +1635,7 @@
             ], 
             "position": {
                 "left": 4429, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1696,7 +1690,7 @@
             ], 
             "position": {
                 "left": 4757, 
-                "top": 252
+                "top": 200
             }, 
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -1728,6 +1722,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "c1faa872-e81d-4614-82d0-010c60302243", 
-    "version": 6
+    "uuid": "d1ac860e-82d6-4f20-ac3a-27385bf43515", 
+    "version": 7
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -27,7 +27,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1b70e058-7820-4dee-80b8-aa2968ca676d"
+                    "uuid": "db236aaf-a297-41cd-8204-c15dd0fb174e"
                 }
             ]
         }, 
@@ -54,7 +54,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "733d2dc9-3a72-4052-9d83-68a17ac956a5"
+                    "uuid": "9be6ea2f-f987-483e-a09d-118a606f55ba"
                 }
             ]
         }, 
@@ -81,7 +81,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "4dc9c780-394d-48db-bd24-0227f485b3cf"
+                    "uuid": "f3decc23-7bc7-4972-8e27-afc143c4b117"
                 }
             ]
         }, 
@@ -108,7 +108,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1f11138b-76fd-47c0-950f-62708dcd6c79"
+                    "uuid": "1f4392d5-688c-4e09-99e5-4645bc9bdb6c"
                 }
             ]
         }, 
@@ -135,7 +135,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "a2ebdf4b-3c3e-4221-a46a-b4580a871adb"
+                    "uuid": "65a31ed4-787c-428b-95e6-4eeed45eed63"
                 }
             ]
         }, 
@@ -158,7 +158,13 @@
                 "left": 290, 
                 "top": 736
             }, 
-            "post_job_actions": {}, 
+            "post_job_actions": {
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "parameter_iteration"
+                }
+            }, 
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3", 
             "tool_shed_repository": {
                 "changeset_revision": "ae4debc68f4a", 
@@ -170,13 +176,7 @@
             "tool_version": "0.0.1+galaxy3", 
             "type": "tool", 
             "uuid": "ac7e7888-f93f-495f-8563-ade504429071", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "parameter_iteration", 
-                    "uuid": "64a1c137-c574-45a0-b174-ddfa27d2717c"
-                }
-            ]
+            "workflow_outputs": []
         }, 
         "6": {
             "annotation": "", 
@@ -1503,6 +1503,11 @@
                     "action_arguments": {}, 
                     "action_type": "DeleteIntermediatesAction", 
                     "output_name": "output"
+                }, 
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
                 }
             }, 
             "tool_id": "__MERGE_COLLECTION__", 
@@ -1510,13 +1515,7 @@
             "tool_version": "1.0.0", 
             "type": "tool", 
             "uuid": "25131a8b-93f5-4134-b5b9-d8567a804260", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "7c2b397a-5a3a-44e0-810b-61d32cb6d85e"
-                }
-            ]
+            "workflow_outputs": []
         }, 
         "30": {
             "annotation": "", 
@@ -1692,6 +1691,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "6e9df4aa-f3a2-4142-9ef5-dd1b20be4a99", 
-    "version": 18
+    "uuid": "34082df6-b119-4e25-9c66-eace9d71edd0", 
+    "version": 19
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -16,7 +16,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 213
+                "top": 258
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -27,7 +27,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "88a20170-58f4-49a1-b8d3-3ea6c982036f"
+                    "uuid": "001d2aa0-ee70-47d8-8d1a-8a53705ad82f"
                 }
             ]
         }, 
@@ -48,7 +48,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 338
+                "top": 383
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -87,7 +87,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 426
+                "top": 471
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -98,7 +98,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "1579ec06-58f6-4a54-80d2-a4ff076492d7"
+                    "uuid": "e8f93eb8-1a81-44aa-98d7-83cef218418e"
                 }
             ]
         }, 
@@ -114,7 +114,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 514
+                "top": 559
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -125,7 +125,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "fa8b08ec-830e-4063-8f14-b7fbc422df62"
+                    "uuid": "6e81bad9-7bd5-42a7-bf92-ab46ac47801e"
                 }
             ]
         }, 
@@ -141,7 +141,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 602
+                "top": 647
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -152,7 +152,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "6df029e6-a8ce-4d05-a134-772b5d0a93ef"
+                    "uuid": "9c058f41-22aa-49cb-9c18-450ddadb32e8"
                 }
             ]
         }, 
@@ -168,7 +168,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 690
+                "top": 735
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -179,7 +179,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "4eed3998-6d91-4f68-a73a-7e02f4299f19"
+                    "uuid": "b32f68ad-fdac-4036-985e-3e7e6f6f0ef9"
                 }
             ]
         }, 
@@ -195,7 +195,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 778
+                "top": 823
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -206,7 +206,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "d33b3e73-2f7c-428b-81ef-52f4c746f535"
+                    "uuid": "a57afc7a-9893-4d92-94f3-0ad57fbcd7ec"
                 }
             ]
         }, 
@@ -227,7 +227,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 866
+                "top": 911
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -271,7 +271,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 954
+                "top": 999
             }, 
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -304,12 +304,7 @@
                     "output_name": "output"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Split file", 
-                    "name": "split_parms"
-                }
-            ], 
+            "inputs": [], 
             "label": "split_metadata_vars", 
             "name": "Split file", 
             "outputs": [
@@ -320,7 +315,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 370
+                "top": 258
             }, 
             "post_job_actions": {
                 "HideDatasetActionlist_output_generic": {
@@ -336,7 +331,7 @@
                 "owner": "bgruening", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"newfilenames\\\": \\\"meta_var_\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"newfilenames\\\": \\\"meta_var_\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
             "tool_version": "0.4.0", 
             "type": "tool", 
             "uuid": "7950e4b1-e497-4365-a46b-833d64ab5ab1", 
@@ -364,7 +359,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 488
+                "top": 533
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -408,7 +403,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 625
+                "top": 670
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -459,7 +454,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 213
+                "top": 376
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -483,9 +478,60 @@
         }, 
         "13": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.6.0+galaxy0", 
+            "content_id": "__RELABEL_FROM_FILE__", 
             "errors": null, 
             "id": 13, 
+            "input_connections": {
+                "how|labels": {
+                    "id": 0, 
+                    "output_name": "output"
+                }, 
+                "input": {
+                    "id": 9, 
+                    "output_name": "list_output_generic"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Relabel List Identifiers", 
+                    "name": "how"
+                }, 
+                {
+                    "description": "runtime parameter for tool Relabel List Identifiers", 
+                    "name": "input"
+                }
+            ], 
+            "label": null, 
+            "name": "Relabel List Identifiers", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 830, 
+                "top": 258
+            }, 
+            "post_job_actions": {}, 
+            "tool_id": "__RELABEL_FROM_FILE__", 
+            "tool_state": "{\"__page__\": null, \"how\": \"{\\\"__current_case__\\\": 0, \\\"how_select\\\": \\\"txt\\\", \\\"labels\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"strict\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "fd1af0bb-5eb3-4946-abdf-dc6201e48db7", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "d06cf89e-612c-4e47-8267-53e5d7ad84e3"
+                }
+            ]
+        }, 
+        "14": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.6.0+galaxy0", 
+            "errors": null, 
+            "id": 14, 
             "input_connections": {
                 "barcodes": {
                     "id": 4, 
@@ -519,7 +565,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 398
+                "top": 405
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -553,19 +599,19 @@
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
             "workflow_outputs": []
         }, 
-        "14": {
+        "15": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 14, 
+            "id": 15, 
             "input_connections": {
                 "inputs_0|input": {
                     "id": 12, 
                     "output_name": "outfile"
                 }, 
                 "inputs_1|input": {
-                    "id": 9, 
-                    "output_name": "list_output_generic"
+                    "id": 13, 
+                    "output_name": "output"
                 }
             }, 
             "inputs": [], 
@@ -578,8 +624,8 @@
                 }
             ], 
             "position": {
-                "left": 830, 
-                "top": 213
+                "left": 1158, 
+                "top": 558
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -595,14 +641,14 @@
             "uuid": "3d8514e4-0a25-41c5-8f09-fbfaf91a52e6", 
             "workflow_outputs": []
         }, 
-        "15": {
+        "16": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 15, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 14, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -629,7 +675,7 @@
             ], 
             "position": {
                 "left": 1158, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -671,14 +717,14 @@
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
             "workflow_outputs": []
         }, 
-        "16": {
+        "17": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 16, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 16, 
                     "output_name": "output_h5ad"
                 }, 
                 "subsets_0|subset": {
@@ -709,7 +755,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -773,14 +819,14 @@
                 }
             ]
         }, 
-        "17": {
+        "18": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 17, 
+            "id": 18, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 17, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -795,7 +841,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -822,14 +868,14 @@
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
             "workflow_outputs": []
         }, 
-        "18": {
+        "19": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 18, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 17, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -856,7 +902,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 369
+                "top": 414
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -920,14 +966,14 @@
                 }
             ]
         }, 
-        "19": {
+        "20": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 19, 
+            "id": 20, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 18, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -942,7 +988,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -969,14 +1015,14 @@
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "20": {
+        "21": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 20, 
+            "id": 21, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 19, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -991,7 +1037,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1018,23 +1064,18 @@
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "21": {
+        "22": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_integrate_harmony/scanpy_integrate_harmony/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 21, 
+            "id": 22, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 20, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy Harmony", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "harmony_batch", 
             "name": "Scanpy Harmony", 
             "outputs": [
@@ -1045,7 +1086,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1061,20 +1102,20 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
             "tool_version": "1.6.0+galaxy1", 
             "type": "tool", 
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 
             "workflow_outputs": []
         }, 
-        "22": {
+        "23": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 22, 
+            "id": 23, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1094,7 +1135,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1116,14 +1157,14 @@
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "23": {
+        "24": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.6.0+galaxy2", 
             "errors": null, 
-            "id": 23, 
+            "id": 24, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|perplexity_file": {
@@ -1146,7 +1187,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 436
+                "top": 481
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1188,14 +1229,14 @@
                 }
             ]
         }, 
-        "24": {
+        "25": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 24, 
+            "id": 25, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1210,7 +1251,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 710
+                "top": 755
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1232,14 +1273,14 @@
             "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
             "workflow_outputs": []
         }, 
-        "25": {
+        "26": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 25, 
+            "id": 26, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|n_neighbors_file": {
@@ -1258,7 +1299,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 866
+                "top": 911
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1287,14 +1328,14 @@
             "uuid": "15106e26-8656-4fc9-ab08-c20a7bbb9e49", 
             "workflow_outputs": []
         }, 
-        "26": {
+        "27": {
             "annotation": "", 
             "content_id": "__BUILD_LIST__", 
             "errors": null, 
-            "id": 26, 
+            "id": 27, 
             "input_connections": {
                 "datasets_0|input": {
-                    "id": 22, 
+                    "id": 23, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1309,30 +1350,30 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 213
+                "top": 258
             }, 
-            "post_job_actions": {}, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
             "tool_id": "__BUILD_LIST__", 
             "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"datasets\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\"}", 
             "tool_version": "1.0.0", 
             "type": "tool", 
             "uuid": "997dad98-f04d-4f38-9199-87ae0905251c", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "9fc95b61-d580-4a95-96f3-eae250f8ae62"
-                }
-            ]
+            "workflow_outputs": []
         }, 
-        "27": {
+        "28": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 27, 
+            "id": 28, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 23, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|resolution_file": {
@@ -1355,7 +1396,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 331
+                "top": 376
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1397,14 +1438,14 @@
                 }
             ]
         }, 
-        "28": {
+        "29": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 28, 
+            "id": 29, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 25, 
+                    "id": 26, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1423,7 +1464,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 605
+                "top": 650
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1463,18 +1504,18 @@
                 }
             ]
         }, 
-        "29": {
+        "30": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 29, 
+            "id": 30, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 27, 
+                    "id": 28, 
                     "output_name": "output_h5ad"
                 }, 
                 "inputs_1|input": {
-                    "id": 26, 
+                    "id": 27, 
                     "output_name": "output"
                 }
             }, 
@@ -1489,34 +1530,34 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 213
+                "top": 258
             }, 
-            "post_job_actions": {}, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
             "tool_id": "__MERGE_COLLECTION__", 
             "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}", 
             "tool_version": "1.0.0", 
             "type": "tool", 
             "uuid": "f871f625-2116-4f96-bcae-5c2775e36be7", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "670b7bec-48b0-472e-bb95-0aecc26a5163"
-                }
-            ]
+            "workflow_outputs": []
         }, 
-        "30": {
+        "31": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 30, 
+            "id": 31, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 23, 
+                    "id": 24, 
                     "output_name": "output_h5ad"
                 }, 
                 "inputs_1|input": {
-                    "id": 28, 
+                    "id": 29, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1531,7 +1572,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 398
+                "top": 443
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1553,18 +1594,18 @@
                 }
             ]
         }, 
-        "31": {
+        "32": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 31, 
+            "id": 32, 
             "input_connections": {
                 "groupby_file": {
-                    "id": 14, 
+                    "id": 15, 
                     "output_name": "output"
                 }, 
                 "input_obj_file": {
-                    "id": 29, 
+                    "id": 30, 
                     "output_name": "output"
                 }
             }, 
@@ -1583,7 +1624,7 @@
             ], 
             "position": {
                 "left": 4101, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1593,7 +1634,7 @@
                 }, 
                 "RenameDatasetActionoutput_tsv": {
                     "action_arguments": {
-                        "newname": "markers_#{input_obj_file}.tsv"
+                        "newname": "markers_#{groupby_file}.tsv"
                     }, 
                     "action_type": "RenameDatasetAction", 
                     "output_name": "output_tsv"
@@ -1618,14 +1659,14 @@
                 }
             ]
         }, 
-        "32": {
+        "33": {
             "annotation": "", 
             "content_id": "__FILTER_FAILED_DATASETS__", 
             "errors": null, 
-            "id": 32, 
+            "id": 33, 
             "input_connections": {
                 "input": {
-                    "id": 31, 
+                    "id": 32, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1640,7 +1681,7 @@
             ], 
             "position": {
                 "left": 4429, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1661,26 +1702,26 @@
             "uuid": "b7d0c5e5-65c5-4366-96aa-21c6653e6399", 
             "workflow_outputs": []
         }, 
-        "33": {
+        "34": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 33, 
+            "id": 34, 
             "input_connections": {
                 "copy_e|embedding_sources": {
-                    "id": 30, 
+                    "id": 31, 
                     "output_name": "output"
                 }, 
                 "copy_o|obs_sources": {
-                    "id": 32, 
+                    "id": 33, 
                     "output_name": "output"
                 }, 
                 "copy_u|uns_sources": {
-                    "id": 32, 
+                    "id": 33, 
                     "output_name": "output"
                 }, 
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 23, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1695,7 +1736,7 @@
             ], 
             "position": {
                 "left": 4757, 
-                "top": 213
+                "top": 258
             }, 
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -1727,6 +1768,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "2a787093-37b7-4f44-9524-12b1008f5072", 
-    "version": 9
+    "uuid": "0675bf7e-0a79-4267-b4e5-8764da5a4104", 
+    "version": 12
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,13 +2,52 @@
     "a_galaxy_workflow": "true", 
     "annotation": "", 
     "format-version": "0.1", 
-    "name": "Scanpy Prod 1.6.0 clustering with Harmony batch adjustment (h5ad)", 
+    "name": "Scanpy Prod 1.6.0 clustering with Harmony batch adjustment (h5ad) - groupby as file", 
     "steps": {
         "0": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0", 
             "errors": null, 
             "id": 0, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "specify_celltype_field", 
+            "name": "Create text file", 
+            "outputs": [
+                {
+                    "name": "outfile", 
+                    "type": "txt"
+                }
+            ], 
+            "position": {
+                "left": 200, 
+                "top": 252
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0", 
+            "tool_shed_repository": {
+                "changeset_revision": "ddf54b12c295", 
+                "name": "text_processing", 
+                "owner": "bgruening", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"token_set\": \"[{\\\"__index__\\\": 0, \\\"line\\\": \\\"CELL_TYPE_FIELD\\\", \\\"repeat_select\\\": {\\\"__current_case__\\\": 0, \\\"repeat_select_opts\\\": \\\"user\\\", \\\"times\\\": \\\"1\\\"}}]\"}", 
+            "tool_version": "1.1.0", 
+            "type": "tool", 
+            "uuid": "2cb41742-cc7b-4313-bdb2-ff2d37481d1c", 
+            "workflow_outputs": []
+        }, 
+        "1": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
+            "errors": null, 
+            "id": 1, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "perplexity", 
@@ -21,7 +60,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 241
+                "top": 377
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -48,11 +87,11 @@
             "uuid": "b2b878e0-3f41-45cd-8472-c7a59c334568", 
             "workflow_outputs": []
         }, 
-        "1": {
+        "2": {
             "annotation": "", 
             "content_id": null, 
             "errors": null, 
-            "id": 1, 
+            "id": 2, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "matrix", 
@@ -60,7 +99,7 @@
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 329
+                "top": 465
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -71,34 +110,7 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "a8f8fcb2-df9c-467b-8892-7609b400e3e0"
-                }
-            ]
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 2, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "genes", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 417
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "b1b82031-8d1c-4253-a25d-c11a10087c64", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "70137a4f-909b-4507-ba01-112b144046b2"
+                    "uuid": "2f273af5-c7d9-4f38-a50e-d3ab33713f3e"
                 }
             ]
         }, 
@@ -109,23 +121,23 @@
             "id": 3, 
             "input_connections": {}, 
             "inputs": [], 
-            "label": "barcodes", 
+            "label": "genes", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 505
+                "top": 553
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
             "tool_version": null, 
             "type": "data_input", 
-            "uuid": "810b3d00-69d4-4097-a6ab-258a30261f60", 
+            "uuid": "b1b82031-8d1c-4253-a25d-c11a10087c64", 
             "workflow_outputs": [
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "ed18f9d5-964a-4072-8865-4c22c4ddcd2a"
+                    "uuid": "96279f0a-ec3f-4235-9457-eb78347a4b64"
                 }
             ]
         }, 
@@ -136,23 +148,23 @@
             "id": 4, 
             "input_connections": {}, 
             "inputs": [], 
-            "label": "cellmeta", 
+            "label": "barcodes", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 593
+                "top": 641
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
             "tool_version": null, 
             "type": "data_input", 
-            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5", 
+            "uuid": "810b3d00-69d4-4097-a6ab-258a30261f60", 
             "workflow_outputs": [
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "d3ff6909-6355-4c0d-9cfe-ab92c55c902d"
+                    "uuid": "8629fa9e-d1b0-4e86-89f7-90bf2205e172"
                 }
             ]
         }, 
@@ -163,12 +175,39 @@
             "id": 5, 
             "input_connections": {}, 
             "inputs": [], 
+            "label": "cellmeta", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 200, 
+                "top": 729
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "277451dd-1e96-46f2-87d9-ff92a0e746af"
+                }
+            ]
+        }, 
+        "6": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 6, 
+            "input_connections": {}, 
+            "inputs": [], 
             "label": "gtf", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
                 "left": 200, 
-                "top": 681
+                "top": 817
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -179,15 +218,15 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "efa6a780-54bb-4bb4-ae65-36f45301b6c9"
+                    "uuid": "51f2609f-b445-420c-81ca-5558a3c78335"
                 }
             ]
         }, 
-        "6": {
+        "7": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
             "errors": null, 
-            "id": 6, 
+            "id": 7, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "resolution", 
@@ -200,7 +239,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 769
+                "top": 905
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -227,11 +266,11 @@
             "uuid": "d1228db0-6989-4ff0-92ba-1116b65cb6fb", 
             "workflow_outputs": []
         }, 
-        "7": {
+        "8": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2", 
             "errors": null, 
-            "id": 7, 
+            "id": 8, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "n_neighbors", 
@@ -244,7 +283,7 @@
             ], 
             "position": {
                 "left": 200, 
-                "top": 857
+                "top": 993
             }, 
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -266,14 +305,52 @@
             "uuid": "a9e2b9c4-7b48-4014-9006-e8c48faa41c5", 
             "workflow_outputs": []
         }, 
-        "8": {
+        "9": {
+            "annotation": "", 
+            "content_id": "__BUILD_LIST__", 
+            "errors": null, 
+            "id": 9, 
+            "input_connections": {
+                "datasets_0|input": {
+                    "id": 0, 
+                    "output_name": "outfile"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Build List", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 502, 
+                "top": 252
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_id": "__BUILD_LIST__", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"datasets\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "6d861117-7b6a-4bf8-be1c-47d0e6a54644", 
+            "workflow_outputs": []
+        }, 
+        "10": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
-            "id": 8, 
+            "id": 10, 
             "input_connections": {
                 "gtf_input": {
-                    "id": 5, 
+                    "id": 6, 
                     "output_name": "output"
                 }
             }, 
@@ -288,7 +365,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 241
+                "top": 489
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -310,14 +387,14 @@
             "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
             "workflow_outputs": []
         }, 
-        "9": {
+        "11": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
-            "id": 9, 
+            "id": 11, 
             "input_connections": {
                 "gtf_input": {
-                    "id": 5, 
+                    "id": 6, 
                     "output_name": "output"
                 }
             }, 
@@ -332,7 +409,7 @@
             ], 
             "position": {
                 "left": 502, 
-                "top": 378
+                "top": 626
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -361,30 +438,79 @@
             "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19", 
             "workflow_outputs": []
         }, 
-        "10": {
+        "12": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2", 
+            "errors": null, 
+            "id": 12, 
+            "input_connections": {
+                "infile": {
+                    "id": 7, 
+                    "output_name": "parameter_iteration"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace Text", 
+                    "name": "infile"
+                }
+            ], 
+            "label": "clusering_slotnames", 
+            "name": "Replace Text", 
+            "outputs": [
+                {
+                    "name": "outfile", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 502, 
+                "top": 369
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "outfile"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2", 
+            "tool_shed_repository": {
+                "changeset_revision": "ddf54b12c295", 
+                "name": "text_processing", 
+                "owner": "bgruening", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"replacements\": \"[{\\\"__index__\\\": 0, \\\"find_pattern\\\": \\\"(.*)\\\", \\\"replace_pattern\\\": \\\"louvain_resolution_\\\\\\\\1\\\"}]\", \"infile\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_version": "1.1.2", 
+            "type": "tool", 
+            "uuid": "fab045e5-d7bf-41eb-bbdf-76d5bc6c3a48", 
+            "workflow_outputs": []
+        }, 
+        "13": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 10, 
+            "id": 13, 
             "input_connections": {
                 "barcodes": {
-                    "id": 3, 
-                    "output_name": "output"
-                }, 
-                "cell_meta": {
                     "id": 4, 
                     "output_name": "output"
                 }, 
+                "cell_meta": {
+                    "id": 5, 
+                    "output_name": "output"
+                }, 
                 "gene_meta": {
-                    "id": 8, 
+                    "id": 10, 
                     "output_name": "feature_annotation"
                 }, 
                 "genes": {
-                    "id": 2, 
+                    "id": 3, 
                     "output_name": "output"
                 }, 
                 "matrix": {
-                    "id": 1, 
+                    "id": 2, 
                     "output_name": "output"
                 }
             }, 
@@ -399,7 +525,7 @@
             ], 
             "position": {
                 "left": 830, 
-                "top": 241
+                "top": 437
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -433,14 +559,56 @@
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
             "workflow_outputs": []
         }, 
-        "11": {
+        "14": {
+            "annotation": "", 
+            "content_id": "__MERGE_COLLECTION__", 
+            "errors": null, 
+            "id": 14, 
+            "input_connections": {
+                "inputs_0|input": {
+                    "id": 12, 
+                    "output_name": "outfile"
+                }, 
+                "inputs_1|input": {
+                    "id": 9, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": "merge_group_slotnames", 
+            "name": "Merge Collections", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 830, 
+                "top": 252
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output"
+                }
+            }, 
+            "tool_id": "__MERGE_COLLECTION__", 
+            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "3d8514e4-0a25-41c5-8f09-fbfaf91a52e6", 
+            "workflow_outputs": []
+        }, 
+        "15": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 11, 
+            "id": 15, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 10, 
+                    "id": 13, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -467,7 +635,7 @@
             ], 
             "position": {
                 "left": 1158, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -509,18 +677,18 @@
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
             "workflow_outputs": []
         }, 
-        "12": {
+        "16": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 12, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 11, 
+                    "id": 15, 
                     "output_name": "output_h5ad"
                 }, 
                 "subsets_0|subset": {
-                    "id": 9, 
+                    "id": 11, 
                     "output_name": "feature_annotation"
                 }
             }, 
@@ -547,7 +715,7 @@
             ], 
             "position": {
                 "left": 1486, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -611,14 +779,14 @@
                 }
             ]
         }, 
-        "13": {
+        "17": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 13, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 12, 
+                    "id": 16, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -633,7 +801,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -660,14 +828,14 @@
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
             "workflow_outputs": []
         }, 
-        "14": {
+        "18": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 14, 
+            "id": 18, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 12, 
+                    "id": 16, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -694,7 +862,7 @@
             ], 
             "position": {
                 "left": 1814, 
-                "top": 397
+                "top": 408
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -758,14 +926,14 @@
                 }
             ]
         }, 
-        "15": {
+        "19": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 15, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 13, 
+                    "id": 17, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -780,7 +948,7 @@
             ], 
             "position": {
                 "left": 2142, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -807,14 +975,14 @@
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "16": {
+        "20": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 16, 
+            "id": 20, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 15, 
+                    "id": 19, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -829,7 +997,7 @@
             ], 
             "position": {
                 "left": 2470, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -856,14 +1024,14 @@
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "17": {
+        "21": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_integrate_harmony/scanpy_integrate_harmony/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 17, 
+            "id": 21, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -878,7 +1046,7 @@
             ], 
             "position": {
                 "left": 2798, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -894,20 +1062,20 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_FIELD\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 0, \\\"default\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"basis\": \"\\\"X_pca\\\"\", \"batch_key\": \"\\\"BATCH_VARIABLE\\\"\", \"__rerun_remap_job_id__\": null, \"adjusted_basis\": \"\\\"X_pca\\\"\"}", 
             "tool_version": "1.6.0+galaxy1", 
             "type": "tool", 
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 
             "workflow_outputs": []
         }, 
-        "18": {
+        "22": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 18, 
+            "id": 22, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -927,7 +1095,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -949,18 +1117,18 @@
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "19": {
+        "23": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.6.0+galaxy2", 
             "errors": null, 
-            "id": 19, 
+            "id": 23, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|perplexity_file": {
-                    "id": 0, 
+                    "id": 1, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -979,7 +1147,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 464
+                "top": 475
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1021,14 +1189,14 @@
                 }
             ]
         }, 
-        "20": {
+        "24": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 20, 
+            "id": 24, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1043,7 +1211,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 738
+                "top": 749
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1065,18 +1233,18 @@
             "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
             "workflow_outputs": []
         }, 
-        "21": {
+        "25": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 21, 
+            "id": 25, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|n_neighbors_file": {
-                    "id": 7, 
+                    "id": 8, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -1091,7 +1259,7 @@
             ], 
             "position": {
                 "left": 3126, 
-                "top": 894
+                "top": 905
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1120,31 +1288,60 @@
             "uuid": "15106e26-8656-4fc9-ab08-c20a7bbb9e49", 
             "workflow_outputs": []
         }, 
-        "22": {
+        "26": {
+            "annotation": "", 
+            "content_id": "__BUILD_LIST__", 
+            "errors": null, 
+            "id": 26, 
+            "input_connections": {
+                "datasets_0|input": {
+                    "id": 22, 
+                    "output_name": "output_h5ad"
+                }
+            }, 
+            "inputs": [], 
+            "label": null, 
+            "name": "Build List", 
+            "outputs": [
+                {
+                    "name": "output", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 3454, 
+                "top": 252
+            }, 
+            "post_job_actions": {}, 
+            "tool_id": "__BUILD_LIST__", 
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"datasets\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "uuid": "997dad98-f04d-4f38-9199-87ae0905251c", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "9fc95b61-d580-4a95-96f3-eae250f8ae62"
+                }
+            ]
+        }, 
+        "27": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 22, 
+            "id": 27, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 18, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|resolution_file": {
-                    "id": 6, 
+                    "id": 7, 
                     "output_name": "parameter_iteration"
                 }
             }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindCluster", 
-                    "name": "settings"
-                }, 
-                {
-                    "description": "runtime parameter for tool Scanpy FindCluster", 
-                    "name": "input_obj_file"
-                }
-            ], 
+            "inputs": [], 
             "label": "find_clusters", 
             "name": "Scanpy FindCluster", 
             "outputs": [
@@ -1159,7 +1356,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 241
+                "top": 370
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1189,7 +1386,7 @@
                 "owner": "ebi-gxa", 
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"directed\\\": \\\"true\\\", \\\"key_added\\\": \\\"METHOD_resolution_RESOLUTION\\\", \\\"layer\\\": \\\"\\\", \\\"neighbors_key\\\": \\\"neighbors\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"resolution\\\": \\\"1.0\\\", \\\"resolution_file\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"restrict_to\\\": \\\"\\\", \\\"use_weights\\\": \\\"false\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"output_cluster\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"\\\"louvain\\\"\"}", 
+            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"directed\\\": \\\"true\\\", \\\"key_added\\\": \\\"METHOD_resolution_RESOLUTION\\\", \\\"layer\\\": \\\"\\\", \\\"neighbors_key\\\": \\\"neighbors\\\", \\\"random_seed\\\": \\\"1234\\\", \\\"resolution\\\": \\\"1.0\\\", \\\"resolution_file\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"restrict_to\\\": \\\"\\\", \\\"use_weights\\\": \\\"false\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"output_cluster\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"method\": \"\\\"louvain\\\"\"}", 
             "tool_version": "1.6.0+galaxy3", 
             "type": "tool", 
             "uuid": "58aec931-0216-43b1-b4ab-177d3dc82a03", 
@@ -1201,80 +1398,14 @@
                 }
             ]
         }, 
-        "23": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy1", 
-            "errors": null, 
-            "id": 23, 
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 18, 
-                    "output_name": "output_h5ad"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
-            "label": "find_markers_cell_type", 
-            "name": "Scanpy FindMarkers", 
-            "outputs": [
-                {
-                    "name": "output_h5ad", 
-                    "type": "h5ad"
-                }, 
-                {
-                    "name": "output_tsv", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 3454, 
-                "top": 515
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_h5ad": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output_h5ad"
-                }, 
-                "RenameDatasetActionoutput_tsv": {
-                    "action_arguments": {
-                        "newname": "celltype_markers.tsv"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_tsv"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy1", 
-            "tool_shed_repository": {
-                "changeset_revision": "cc776860fae1", 
-                "name": "scanpy_find_markers", 
-                "owner": "ebi-gxa", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"key_added\\\": \\\"markers_GROUPBY\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"pts\\\": \\\"false\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"tie_correct\\\": \\\"false\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"CELL_TYPE_FIELD\\\"\"}", 
-            "tool_version": "1.6.0+galaxy1", 
-            "type": "tool", 
-            "uuid": "39d48646-ebad-4b6f-b031-fa70e0532f94", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output_tsv", 
-                    "uuid": "6da718b2-ea33-4879-8664-3c7c6465f3e6"
-                }
-            ]
-        }, 
-        "24": {
+        "28": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 24, 
+            "id": 28, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 25, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1293,7 +1424,7 @@
             ], 
             "position": {
                 "left": 3454, 
-                "top": 719
+                "top": 644
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1333,86 +1464,24 @@
                 }
             ]
         }, 
-        "25": {
+        "29": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy1", 
+            "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 25, 
+            "id": 29, 
             "input_connections": {
-                "input_obj_file": {
-                    "id": 22, 
-                    "output_name": "output_h5ad"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindMarkers", 
-                    "name": "input_obj_file"
-                }
-            ], 
-            "label": "find_markers", 
-            "name": "Scanpy FindMarkers", 
-            "outputs": [
-                {
-                    "name": "output_h5ad", 
-                    "type": "h5ad"
-                }, 
-                {
-                    "name": "output_tsv", 
-                    "type": "tabular"
-                }
-            ], 
-            "position": {
-                "left": 3782, 
-                "top": 241
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionoutput_h5ad": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
+                "inputs_0|input": {
+                    "id": 27, 
                     "output_name": "output_h5ad"
                 }, 
-                "RenameDatasetActionoutput_tsv": {
-                    "action_arguments": {
-                        "newname": "markers_#{input_obj_file}.tsv"
-                    }, 
-                    "action_type": "RenameDatasetAction", 
-                    "output_name": "output_tsv"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy1", 
-            "tool_shed_repository": {
-                "changeset_revision": "cc776860fae1", 
-                "name": "scanpy_find_markers", 
-                "owner": "ebi-gxa", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": null, \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"key_added\\\": \\\"markers_GROUPBY\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"pts\\\": \\\"false\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"tie_correct\\\": \\\"false\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"INPUT_OBJ\\\"\"}", 
-            "tool_version": "1.6.0+galaxy1", 
-            "type": "tool", 
-            "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output_tsv", 
-                    "uuid": "3d5c9c33-70df-4e2f-b584-eba55046dd5d"
-                }
-            ]
-        }, 
-        "26": {
-            "annotation": "", 
-            "content_id": "__BUILD_LIST__", 
-            "errors": null, 
-            "id": 26, 
-            "input_connections": {
-                "datasets_0|input": {
-                    "id": 23, 
-                    "output_name": "output_h5ad"
+                "inputs_1|input": {
+                    "id": 26, 
+                    "output_name": "output"
                 }
             }, 
             "inputs": [], 
             "label": null, 
-            "name": "Build List", 
+            "name": "Merge Collections", 
             "outputs": [
                 {
                     "name": "output", 
@@ -1421,39 +1490,34 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 467
+                "top": 252
             }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_id": "__BUILD_LIST__", 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"datasets\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\"}", 
+            "post_job_actions": {}, 
+            "tool_id": "__MERGE_COLLECTION__", 
+            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}", 
             "tool_version": "1.0.0", 
             "type": "tool", 
-            "uuid": "bc0cc83e-33f8-4dba-9510-71024fde2fc5", 
-            "workflow_outputs": []
+            "uuid": "f871f625-2116-4f96-bcae-5c2775e36be7", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "670b7bec-48b0-472e-bb95-0aecc26a5163"
+                }
+            ]
         }, 
-        "27": {
+        "30": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 27, 
+            "id": 30, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 19, 
+                    "id": 23, 
                     "output_name": "output_h5ad"
                 }, 
                 "inputs_1|input": {
-                    "id": 24, 
+                    "id": 28, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1468,7 +1532,7 @@
             ], 
             "position": {
                 "left": 3782, 
-                "top": 584
+                "top": 437
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1490,19 +1554,84 @@
                 }
             ]
         }, 
-        "28": {
+        "31": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy3", 
+            "errors": null, 
+            "id": 31, 
+            "input_connections": {
+                "groupby_file": {
+                    "id": 14, 
+                    "output_name": "output"
+                }, 
+                "input_obj_file": {
+                    "id": 29, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "label": "find_markers", 
+            "name": "Scanpy FindMarkers", 
+            "outputs": [
+                {
+                    "name": "output_h5ad", 
+                    "type": "h5ad"
+                }, 
+                {
+                    "name": "output_tsv", 
+                    "type": "tabular"
+                }
+            ], 
+            "position": {
+                "left": 4101, 
+                "top": 252
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput_h5ad": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output_h5ad"
+                }, 
+                "RenameDatasetActionoutput_tsv": {
+                    "action_arguments": {
+                        "newname": "markers_#{input_obj_file}.tsv"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
+                    "output_name": "output_tsv"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy3", 
+            "tool_shed_repository": {
+                "changeset_revision": "f04dd4e5b6a7", 
+                "name": "scanpy_find_markers", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"groupby_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"input_format\": \"\\\"anndata\\\"\", \"settings\": \"{\\\"__current_case__\\\": 1, \\\"default\\\": \\\"false\\\", \\\"groups\\\": \\\"\\\", \\\"key_added\\\": \\\"markers_GROUPBY\\\", \\\"max_out_group_fraction\\\": \\\"1.0\\\", \\\"method\\\": \\\"t-test_overestim_var\\\", \\\"min_fold_change\\\": \\\"1.0\\\", \\\"min_in_group_fraction\\\": \\\"0.0\\\", \\\"pts\\\": \\\"false\\\", \\\"rankby_abs\\\": \\\"false\\\", \\\"reference\\\": \\\"rest\\\", \\\"tie_correct\\\": \\\"false\\\", \\\"use_raw\\\": \\\"true\\\"}\", \"input_obj_file\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"output_format\": \"\\\"anndata_h5ad\\\"\", \"n_genes\": \"\\\"100\\\"\", \"output_markers\": \"\\\"true\\\"\", \"__rerun_remap_job_id__\": null, \"groupby\": \"\\\"INPUT_OBJ\\\"\"}", 
+            "tool_version": "1.6.0+galaxy3", 
+            "type": "tool", 
+            "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output_tsv", 
+                    "uuid": "3d5c9c33-70df-4e2f-b584-eba55046dd5d"
+                }
+            ]
+        }, 
+        "32": {
             "annotation": "", 
             "content_id": "__FILTER_FAILED_DATASETS__", 
             "errors": null, 
-            "id": 28, 
+            "id": 32, 
             "input_connections": {
                 "input": {
-                    "id": 25, 
+                    "id": 31, 
                     "output_name": "output_h5ad"
                 }
             }, 
             "inputs": [], 
-            "label": "Filtered cluster markers", 
+            "label": "Filtered cellgroup markers", 
             "name": "Filter failed", 
             "outputs": [
                 {
@@ -1511,8 +1640,8 @@
                 }
             ], 
             "position": {
-                "left": 4110, 
-                "top": 241
+                "left": 4429, 
+                "top": 252
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1533,116 +1662,26 @@
             "uuid": "b7d0c5e5-65c5-4366-96aa-21c6653e6399", 
             "workflow_outputs": []
         }, 
-        "29": {
-            "annotation": "", 
-            "content_id": "__FILTER_FAILED_DATASETS__", 
-            "errors": null, 
-            "id": 29, 
-            "input_connections": {
-                "input": {
-                    "id": 26, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": "Filtered cell type marker", 
-            "name": "Filter failed", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 4110, 
-                "top": 378
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_id": "__FILTER_FAILED_DATASETS__", 
-            "tool_state": "{\"input\": \"{\\\"__class__\\\": \\\"ConnectedValue\\\"}\", \"__rerun_remap_job_id__\": null, \"__page__\": null}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "8c43f7fe-d744-401d-aada-69a1bff03052", 
-            "workflow_outputs": []
-        }, 
-        "30": {
-            "annotation": "", 
-            "content_id": "__MERGE_COLLECTION__", 
-            "errors": null, 
-            "id": 30, 
-            "input_connections": {
-                "inputs_0|input": {
-                    "id": 28, 
-                    "output_name": "output"
-                }, 
-                "inputs_1|input": {
-                    "id": 29, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": "merged_markers", 
-            "name": "Merge Collections", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 4438, 
-                "top": 241
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "output"
-                }, 
-                "HideDatasetActionoutput": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "output"
-                }
-            }, 
-            "tool_id": "__MERGE_COLLECTION__", 
-            "tool_state": "{\"inputs\": \"[{\\\"__index__\\\": 0, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}, {\\\"__index__\\\": 1, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}}]\", \"__rerun_remap_job_id__\": null, \"advanced\": \"{\\\"conflict\\\": {\\\"__current_case__\\\": 3, \\\"duplicate_options\\\": \\\"keep_first\\\"}}\", \"__page__\": null}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "ad8d8046-c66c-4458-a30c-14699c1e13ef", 
-            "workflow_outputs": []
-        }, 
-        "31": {
+        "33": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 31, 
+            "id": 33, 
             "input_connections": {
                 "copy_e|embedding_sources": {
-                    "id": 27, 
+                    "id": 30, 
                     "output_name": "output"
                 }, 
                 "copy_o|obs_sources": {
-                    "id": 30, 
+                    "id": 32, 
                     "output_name": "output"
                 }, 
                 "copy_u|uns_sources": {
-                    "id": 30, 
+                    "id": 32, 
                     "output_name": "output"
                 }, 
                 "input_obj_file": {
-                    "id": 18, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1657,7 +1696,7 @@
             ], 
             "position": {
                 "left": 4757, 
-                "top": 241
+                "top": 252
             }, 
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -1689,6 +1728,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "d1c92510-45e1-4787-b4ce-935c827c1871", 
-    "version": 47
+    "uuid": "c1faa872-e81d-4614-82d0-010c60302243", 
+    "version": 6
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -11,191 +11,12 @@
             "id": 0, 
             "input_connections": {}, 
             "inputs": [], 
-            "label": "metadata_group_vars", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 258
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "2caa8b9e-85d0-4280-8c7c-fa513bc03a53", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "001d2aa0-ee70-47d8-8d1a-8a53705ad82f"
-                }
-            ]
-        }, 
-        "1": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
-            "errors": null, 
-            "id": 1, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "perplexity", 
-            "name": "Scanpy ParameterIterator", 
-            "outputs": [
-                {
-                    "name": "parameter_iteration", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 200, 
-                "top": 383
-            }, 
-            "post_job_actions": {
-                "DeleteIntermediatesActionparameter_iteration": {
-                    "action_arguments": {}, 
-                    "action_type": "DeleteIntermediatesAction", 
-                    "output_name": "parameter_iteration"
-                }, 
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "parameter_iteration"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
-            "tool_shed_repository": {
-                "changeset_revision": "f0dd61087af3", 
-                "name": "scanpy_parameter_iterator", 
-                "owner": "ebi-gxa", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"input_type\": \"{\\\"__current_case__\\\": 0, \\\"input_values\\\": \\\"1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50\\\", \\\"parameter_values\\\": \\\"list_comma_separated_values\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"parameter_name\": \"\\\"perplexity\\\"\"}", 
-            "tool_version": "0.0.1+galaxy1", 
-            "type": "tool", 
-            "uuid": "b2b878e0-3f41-45cd-8472-c7a59c334568", 
-            "workflow_outputs": []
-        }, 
-        "2": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 2, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "matrix", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 471
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "5908f4f6-4bb5-46ef-876c-86d9ebb899cc", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "e8f93eb8-1a81-44aa-98d7-83cef218418e"
-                }
-            ]
-        }, 
-        "3": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 3, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "genes", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 559
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "b1b82031-8d1c-4253-a25d-c11a10087c64", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "6e81bad9-7bd5-42a7-bf92-ab46ac47801e"
-                }
-            ]
-        }, 
-        "4": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 4, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "barcodes", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 647
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "810b3d00-69d4-4097-a6ab-258a30261f60", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "9c058f41-22aa-49cb-9c18-450ddadb32e8"
-                }
-            ]
-        }, 
-        "5": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 5, 
-            "input_connections": {}, 
-            "inputs": [], 
-            "label": "cellmeta", 
-            "name": "Input dataset", 
-            "outputs": [], 
-            "position": {
-                "left": 200, 
-                "top": 735
-            }, 
-            "tool_id": null, 
-            "tool_state": "{}", 
-            "tool_version": null, 
-            "type": "data_input", 
-            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "b32f68ad-fdac-4036-985e-3e7e6f6f0ef9"
-                }
-            ]
-        }, 
-        "6": {
-            "annotation": "", 
-            "content_id": null, 
-            "errors": null, 
-            "id": 6, 
-            "input_connections": {}, 
-            "inputs": [], 
             "label": "gtf", 
             "name": "Input dataset", 
             "outputs": [], 
             "position": {
-                "left": 200, 
-                "top": 823
+                "left": 290, 
+                "top": 296
             }, 
             "tool_id": null, 
             "tool_state": "{}", 
@@ -206,15 +27,162 @@
                 {
                     "label": null, 
                     "output_name": "output", 
-                    "uuid": "a57afc7a-9893-4d92-94f3-0ad57fbcd7ec"
+                    "uuid": "1b70e058-7820-4dee-80b8-aa2968ca676d"
                 }
             ]
         }, 
-        "7": {
+        "1": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 1, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "matrix", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 290, 
+                "top": 384
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "5908f4f6-4bb5-46ef-876c-86d9ebb899cc", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "733d2dc9-3a72-4052-9d83-68a17ac956a5"
+                }
+            ]
+        }, 
+        "2": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 2, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "genes", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 290, 
+                "top": 472
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "b1b82031-8d1c-4253-a25d-c11a10087c64", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "4dc9c780-394d-48db-bd24-0227f485b3cf"
+                }
+            ]
+        }, 
+        "3": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 3, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "barcodes", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 290, 
+                "top": 560
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "810b3d00-69d4-4097-a6ab-258a30261f60", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "1f11138b-76fd-47c0-950f-62708dcd6c79"
+                }
+            ]
+        }, 
+        "4": {
+            "annotation": "", 
+            "content_id": null, 
+            "errors": null, 
+            "id": 4, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "cellmeta", 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 290, 
+                "top": 648
+            }, 
+            "tool_id": null, 
+            "tool_state": "{}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "output", 
+                    "uuid": "a2ebdf4b-3c3e-4221-a46a-b4580a871adb"
+                }
+            ]
+        }, 
+        "5": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3", 
+            "errors": null, 
+            "id": 5, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "meta_vars", 
+            "name": "Scanpy ParameterIterator", 
+            "outputs": [
+                {
+                    "name": "parameter_iteration", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 290, 
+                "top": 736
+            }, 
+            "post_job_actions": {}, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3", 
+            "tool_shed_repository": {
+                "changeset_revision": "ae4debc68f4a", 
+                "name": "scanpy_parameter_iterator", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__page__\": null, \"input_type\": \"{\\\"__current_case__\\\": 0, \\\"input_values\\\": \\\"CELL_TYPE_FIELD\\\", \\\"parameter_values\\\": \\\"list_comma_separated_values\\\"}\", \"__rerun_remap_job_id__\": null, \"parameter_name\": \"\\\"meta\\\"\"}", 
+            "tool_version": "0.0.1+galaxy3", 
+            "type": "tool", 
+            "uuid": "ac7e7888-f93f-495f-8563-ade504429071", 
+            "workflow_outputs": [
+                {
+                    "label": null, 
+                    "output_name": "parameter_iteration", 
+                    "uuid": "64a1c137-c574-45a0-b174-ddfa27d2717c"
+                }
+            ]
+        }, 
+        "6": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
             "errors": null, 
-            "id": 7, 
+            "id": 6, 
             "input_connections": {}, 
             "inputs": [], 
             "label": "resolution", 
@@ -226,8 +194,8 @@
                 }
             ], 
             "position": {
-                "left": 200, 
-                "top": 911
+                "left": 290, 
+                "top": 824
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -254,6 +222,50 @@
             "uuid": "d1228db0-6989-4ff0-92ba-1116b65cb6fb", 
             "workflow_outputs": []
         }, 
+        "7": {
+            "annotation": "", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
+            "errors": null, 
+            "id": 7, 
+            "input_connections": {}, 
+            "inputs": [], 
+            "label": "perplexity", 
+            "name": "Scanpy ParameterIterator", 
+            "outputs": [
+                {
+                    "name": "parameter_iteration", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 290, 
+                "top": 912
+            }, 
+            "post_job_actions": {
+                "DeleteIntermediatesActionparameter_iteration": {
+                    "action_arguments": {}, 
+                    "action_type": "DeleteIntermediatesAction", 
+                    "output_name": "parameter_iteration"
+                }, 
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "parameter_iteration"
+                }
+            }, 
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1", 
+            "tool_shed_repository": {
+                "changeset_revision": "f0dd61087af3", 
+                "name": "scanpy_parameter_iterator", 
+                "owner": "ebi-gxa", 
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            }, 
+            "tool_state": "{\"__job_resource\": \"{\\\"__current_case__\\\": 0, \\\"__job_resource__select\\\": \\\"no\\\"}\", \"input_type\": \"{\\\"__current_case__\\\": 0, \\\"input_values\\\": \\\"1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50\\\", \\\"parameter_values\\\": \\\"list_comma_separated_values\\\"}\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"parameter_name\": \"\\\"perplexity\\\"\"}", 
+            "tool_version": "0.0.1+galaxy1", 
+            "type": "tool", 
+            "uuid": "b2b878e0-3f41-45cd-8472-c7a59c334568", 
+            "workflow_outputs": []
+        }, 
         "8": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2", 
@@ -270,8 +282,8 @@
                 }
             ], 
             "position": {
-                "left": 200, 
-                "top": 999
+                "left": 290, 
+                "top": 1000
             }, 
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -295,56 +307,12 @@
         }, 
         "9": {
             "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.4.0", 
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
             "id": 9, 
             "input_connections": {
-                "split_parms|input": {
-                    "id": 0, 
-                    "output_name": "output"
-                }
-            }, 
-            "inputs": [], 
-            "label": "split_metadata_vars", 
-            "name": "Split file", 
-            "outputs": [
-                {
-                    "name": "list_output_generic", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 502, 
-                "top": 258
-            }, 
-            "post_job_actions": {
-                "HideDatasetActionlist_output_generic": {
-                    "action_arguments": {}, 
-                    "action_type": "HideDatasetAction", 
-                    "output_name": "list_output_generic"
-                }
-            }, 
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.4.0", 
-            "tool_shed_repository": {
-                "changeset_revision": "e77b954f0da5", 
-                "name": "split_file_to_collection", 
-                "owner": "bgruening", 
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            }, 
-            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"split_parms\": \"{\\\"__current_case__\\\": 6, \\\"input\\\": {\\\"__class__\\\": \\\"ConnectedValue\\\"}, \\\"newfilenames\\\": \\\"meta_var_\\\", \\\"select_allocate\\\": {\\\"__current_case__\\\": 2, \\\"allocate\\\": \\\"byrow\\\"}, \\\"select_ftype\\\": \\\"generic\\\", \\\"select_mode\\\": {\\\"__current_case__\\\": 0, \\\"chunksize\\\": \\\"1\\\", \\\"mode\\\": \\\"chunk\\\"}, \\\"split_method\\\": {\\\"__current_case__\\\": 1, \\\"record_length\\\": \\\"1\\\", \\\"select_split_method\\\": \\\"number\\\"}}\"}", 
-            "tool_version": "0.4.0", 
-            "type": "tool", 
-            "uuid": "7950e4b1-e497-4365-a46b-833d64ab5ab1", 
-            "workflow_outputs": []
-        }, 
-        "10": {
-            "annotation": "", 
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
-            "errors": null, 
-            "id": 10, 
-            "input_connections": {
                 "gtf_input": {
-                    "id": 6, 
+                    "id": 0, 
                     "output_name": "output"
                 }
             }, 
@@ -358,8 +326,8 @@
                 }
             ], 
             "position": {
-                "left": 502, 
-                "top": 533
+                "left": 592, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionfeature_annotation": {
@@ -381,14 +349,14 @@
             "uuid": "807d0865-881f-4491-b48a-01249910afcc", 
             "workflow_outputs": []
         }, 
-        "11": {
+        "10": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4", 
             "errors": null, 
-            "id": 11, 
+            "id": 10, 
             "input_connections": {
                 "gtf_input": {
-                    "id": 6, 
+                    "id": 0, 
                     "output_name": "output"
                 }
             }, 
@@ -402,8 +370,8 @@
                 }
             ], 
             "position": {
-                "left": 502, 
-                "top": 670
+                "left": 592, 
+                "top": 433
             }, 
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -432,14 +400,14 @@
             "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19", 
             "workflow_outputs": []
         }, 
-        "12": {
+        "11": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2", 
             "errors": null, 
-            "id": 12, 
+            "id": 11, 
             "input_connections": {
                 "infile": {
-                    "id": 7, 
+                    "id": 6, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -453,13 +421,20 @@
                 }
             ], 
             "position": {
-                "left": 502, 
-                "top": 376
+                "left": 592, 
+                "top": 570
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
                     "action_arguments": {}, 
                     "action_type": "HideDatasetAction", 
+                    "output_name": "outfile"
+                }, 
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "#{infile}"
+                    }, 
+                    "action_type": "RenameDatasetAction", 
                     "output_name": "outfile"
                 }
             }, 
@@ -476,81 +451,30 @@
             "uuid": "fab045e5-d7bf-41eb-bbdf-76d5bc6c3a48", 
             "workflow_outputs": []
         }, 
-        "13": {
-            "annotation": "", 
-            "content_id": "__RELABEL_FROM_FILE__", 
-            "errors": null, 
-            "id": 13, 
-            "input_connections": {
-                "how|labels": {
-                    "id": 0, 
-                    "output_name": "output"
-                }, 
-                "input": {
-                    "id": 9, 
-                    "output_name": "list_output_generic"
-                }
-            }, 
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Relabel List Identifiers", 
-                    "name": "how"
-                }, 
-                {
-                    "description": "runtime parameter for tool Relabel List Identifiers", 
-                    "name": "input"
-                }
-            ], 
-            "label": null, 
-            "name": "Relabel List Identifiers", 
-            "outputs": [
-                {
-                    "name": "output", 
-                    "type": "input"
-                }
-            ], 
-            "position": {
-                "left": 830, 
-                "top": 258
-            }, 
-            "post_job_actions": {}, 
-            "tool_id": "__RELABEL_FROM_FILE__", 
-            "tool_state": "{\"__page__\": null, \"how\": \"{\\\"__current_case__\\\": 0, \\\"how_select\\\": \\\"txt\\\", \\\"labels\\\": {\\\"__class__\\\": \\\"RuntimeValue\\\"}, \\\"strict\\\": \\\"false\\\"}\", \"__rerun_remap_job_id__\": null, \"input\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
-            "tool_version": "1.0.0", 
-            "type": "tool", 
-            "uuid": "fd1af0bb-5eb3-4946-abdf-dc6201e48db7", 
-            "workflow_outputs": [
-                {
-                    "label": null, 
-                    "output_name": "output", 
-                    "uuid": "d06cf89e-612c-4e47-8267-53e5d7ad84e3"
-                }
-            ]
-        }, 
-        "14": {
+        "12": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 14, 
+            "id": 12, 
             "input_connections": {
                 "barcodes": {
-                    "id": 4, 
-                    "output_name": "output"
-                }, 
-                "cell_meta": {
-                    "id": 5, 
-                    "output_name": "output"
-                }, 
-                "gene_meta": {
-                    "id": 10, 
-                    "output_name": "feature_annotation"
-                }, 
-                "genes": {
                     "id": 3, 
                     "output_name": "output"
                 }, 
-                "matrix": {
+                "cell_meta": {
+                    "id": 4, 
+                    "output_name": "output"
+                }, 
+                "gene_meta": {
+                    "id": 9, 
+                    "output_name": "feature_annotation"
+                }, 
+                "genes": {
                     "id": 2, 
+                    "output_name": "output"
+                }, 
+                "matrix": {
+                    "id": 1, 
                     "output_name": "output"
                 }
             }, 
@@ -564,8 +488,8 @@
                 }
             ], 
             "position": {
-                "left": 830, 
-                "top": 405
+                "left": 920, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -599,19 +523,19 @@
             "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f", 
             "workflow_outputs": []
         }, 
-        "15": {
+        "13": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 15, 
+            "id": 13, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 12, 
+                    "id": 11, 
                     "output_name": "outfile"
                 }, 
                 "inputs_1|input": {
-                    "id": 13, 
-                    "output_name": "output"
+                    "id": 5, 
+                    "output_name": "parameter_iteration"
                 }
             }, 
             "inputs": [], 
@@ -624,8 +548,8 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 558
+                "left": 920, 
+                "top": 568
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -641,14 +565,14 @@
             "uuid": "3d8514e4-0a25-41c5-8f09-fbfaf91a52e6", 
             "workflow_outputs": []
         }, 
-        "16": {
+        "14": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_cells/scanpy_filter_cells/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 16, 
+            "id": 14, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 14, 
+                    "id": 12, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -674,8 +598,8 @@
                 }
             ], 
             "position": {
-                "left": 1158, 
-                "top": 258
+                "left": 1248, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -717,18 +641,18 @@
             "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb", 
             "workflow_outputs": []
         }, 
-        "17": {
+        "15": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_filter_genes/scanpy_filter_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 17, 
+            "id": 15, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 16, 
+                    "id": 14, 
                     "output_name": "output_h5ad"
                 }, 
                 "subsets_0|subset": {
-                    "id": 11, 
+                    "id": 10, 
                     "output_name": "feature_annotation"
                 }
             }, 
@@ -754,8 +678,8 @@
                 }
             ], 
             "position": {
-                "left": 1486, 
-                "top": 258
+                "left": 1576, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -819,14 +743,14 @@
                 }
             ]
         }, 
-        "18": {
+        "16": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 18, 
+            "id": 16, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 15, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -840,8 +764,8 @@
                 }
             ], 
             "position": {
-                "left": 1814, 
-                "top": 258
+                "left": 1904, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -868,14 +792,14 @@
             "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34", 
             "workflow_outputs": []
         }, 
-        "19": {
+        "17": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 19, 
+            "id": 17, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 17, 
+                    "id": 15, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -901,8 +825,8 @@
                 }
             ], 
             "position": {
-                "left": 1814, 
-                "top": 414
+                "left": 1904, 
+                "top": 452
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -966,14 +890,14 @@
                 }
             ]
         }, 
-        "20": {
+        "18": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_variable_genes/scanpy_find_variable_genes/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 20, 
+            "id": 18, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 18, 
+                    "id": 16, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -987,8 +911,8 @@
                 }
             ], 
             "position": {
-                "left": 2142, 
-                "top": 258
+                "left": 2232, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1015,14 +939,14 @@
             "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b", 
             "workflow_outputs": []
         }, 
-        "21": {
+        "19": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_pca/scanpy_run_pca/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 21, 
+            "id": 19, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 20, 
+                    "id": 18, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1036,8 +960,8 @@
                 }
             ], 
             "position": {
-                "left": 2470, 
-                "top": 258
+                "left": 2560, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1064,14 +988,14 @@
             "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28", 
             "workflow_outputs": []
         }, 
-        "22": {
+        "20": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_integrate_harmony/scanpy_integrate_harmony/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 22, 
+            "id": 20, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 21, 
+                    "id": 19, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1085,8 +1009,8 @@
                 }
             ], 
             "position": {
-                "left": 2798, 
-                "top": 258
+                "left": 2888, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1108,14 +1032,14 @@
             "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05", 
             "workflow_outputs": []
         }, 
-        "23": {
+        "21": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 23, 
+            "id": 21, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1134,8 +1058,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 258
+                "left": 3216, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1157,18 +1081,18 @@
             "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a", 
             "workflow_outputs": []
         }, 
-        "24": {
+        "22": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.6.0+galaxy2", 
             "errors": null, 
-            "id": 24, 
+            "id": 22, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|perplexity_file": {
-                    "id": 1, 
+                    "id": 7, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -1186,8 +1110,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 481
+                "left": 3216, 
+                "top": 519
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1229,14 +1153,14 @@
                 }
             ]
         }, 
-        "25": {
+        "23": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0", 
             "errors": null, 
-            "id": 25, 
+            "id": 23, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1250,8 +1174,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 755
+                "left": 3216, 
+                "top": 793
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_png": {
@@ -1273,14 +1197,14 @@
             "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2", 
             "workflow_outputs": []
         }, 
-        "26": {
+        "24": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 26, 
+            "id": 24, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 22, 
+                    "id": 20, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|n_neighbors_file": {
@@ -1298,8 +1222,8 @@
                 }
             ], 
             "position": {
-                "left": 3126, 
-                "top": 911
+                "left": 3216, 
+                "top": 949
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1328,14 +1252,14 @@
             "uuid": "15106e26-8656-4fc9-ab08-c20a7bbb9e49", 
             "workflow_outputs": []
         }, 
-        "27": {
+        "25": {
             "annotation": "", 
             "content_id": "__BUILD_LIST__", 
             "errors": null, 
-            "id": 27, 
+            "id": 25, 
             "input_connections": {
                 "datasets_0|input": {
-                    "id": 23, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1349,8 +1273,8 @@
                 }
             ], 
             "position": {
-                "left": 3454, 
-                "top": 258
+                "left": 3544, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1366,18 +1290,18 @@
             "uuid": "997dad98-f04d-4f38-9199-87ae0905251c", 
             "workflow_outputs": []
         }, 
-        "28": {
+        "26": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 28, 
+            "id": 26, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 23, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }, 
                 "settings|resolution_file": {
-                    "id": 7, 
+                    "id": 6, 
                     "output_name": "parameter_iteration"
                 }
             }, 
@@ -1395,8 +1319,8 @@
                 }
             ], 
             "position": {
-                "left": 3454, 
-                "top": 376
+                "left": 3544, 
+                "top": 414
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1438,14 +1362,14 @@
                 }
             ]
         }, 
-        "29": {
+        "27": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 29, 
+            "id": 27, 
             "input_connections": {
                 "input_obj_file": {
-                    "id": 26, 
+                    "id": 24, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1463,8 +1387,8 @@
                 }
             ], 
             "position": {
-                "left": 3454, 
-                "top": 650
+                "left": 3544, 
+                "top": 688
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1504,18 +1428,18 @@
                 }
             ]
         }, 
-        "30": {
+        "28": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 30, 
+            "id": 28, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 28, 
+                    "id": 26, 
                     "output_name": "output_h5ad"
                 }, 
                 "inputs_1|input": {
-                    "id": 27, 
+                    "id": 25, 
                     "output_name": "output"
                 }
             }, 
@@ -1529,8 +1453,8 @@
                 }
             ], 
             "position": {
-                "left": 3782, 
-                "top": 258
+                "left": 3872, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1546,18 +1470,18 @@
             "uuid": "f871f625-2116-4f96-bcae-5c2775e36be7", 
             "workflow_outputs": []
         }, 
-        "31": {
+        "29": {
             "annotation": "", 
             "content_id": "__MERGE_COLLECTION__", 
             "errors": null, 
-            "id": 31, 
+            "id": 29, 
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 24, 
+                    "id": 22, 
                     "output_name": "output_h5ad"
                 }, 
                 "inputs_1|input": {
-                    "id": 29, 
+                    "id": 27, 
                     "output_name": "output_h5"
                 }
             }, 
@@ -1571,8 +1495,8 @@
                 }
             ], 
             "position": {
-                "left": 3782, 
-                "top": 443
+                "left": 3872, 
+                "top": 481
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1594,18 +1518,18 @@
                 }
             ]
         }, 
-        "32": {
+        "30": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy3", 
             "errors": null, 
-            "id": 32, 
+            "id": 30, 
             "input_connections": {
                 "groupby_file": {
-                    "id": 15, 
+                    "id": 13, 
                     "output_name": "output"
                 }, 
                 "input_obj_file": {
-                    "id": 30, 
+                    "id": 28, 
                     "output_name": "output"
                 }
             }, 
@@ -1623,8 +1547,8 @@
                 }
             ], 
             "position": {
-                "left": 4101, 
-                "top": 258
+                "left": 4191, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1659,14 +1583,14 @@
                 }
             ]
         }, 
-        "33": {
+        "31": {
             "annotation": "", 
             "content_id": "__FILTER_FAILED_DATASETS__", 
             "errors": null, 
-            "id": 33, 
+            "id": 31, 
             "input_connections": {
                 "input": {
-                    "id": 32, 
+                    "id": 30, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1680,8 +1604,8 @@
                 }
             ], 
             "position": {
-                "left": 4429, 
-                "top": 258
+                "left": 4519, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1702,26 +1626,26 @@
             "uuid": "b7d0c5e5-65c5-4366-96aa-21c6653e6399", 
             "workflow_outputs": []
         }, 
-        "34": {
+        "32": {
             "annotation": "", 
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.6.0+galaxy1", 
             "errors": null, 
-            "id": 34, 
+            "id": 32, 
             "input_connections": {
                 "copy_e|embedding_sources": {
-                    "id": 31, 
+                    "id": 29, 
                     "output_name": "output"
                 }, 
                 "copy_o|obs_sources": {
-                    "id": 33, 
+                    "id": 31, 
                     "output_name": "output"
                 }, 
                 "copy_u|uns_sources": {
-                    "id": 33, 
+                    "id": 31, 
                     "output_name": "output"
                 }, 
                 "input_obj_file": {
-                    "id": 23, 
+                    "id": 21, 
                     "output_name": "output_h5ad"
                 }
             }, 
@@ -1735,8 +1659,8 @@
                 }
             ], 
             "position": {
-                "left": 4757, 
-                "top": 258
+                "left": 4847, 
+                "top": 296
             }, 
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -1768,6 +1692,6 @@
         }
     }, 
     "tags": [], 
-    "uuid": "0675bf7e-0a79-4267-b4e5-8764da5a4104", 
-    "version": 12
+    "uuid": "6e9df4aa-f3a2-4142-9ef5-dd1b20be4a99", 
+    "version": 18
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -160,7 +160,12 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
-metadata_group_vars: {}
+meta_vars:
+    input_type:
+        __current_case__: 0
+        input_values: CELL_TYPE_FIELD
+        parameter_values: list_comma_separated_values
+    parameter_name: meta
 n_neighbors:
     input_type:
         __current_case__: 0
@@ -319,21 +324,3 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
-split_metadata_vars:
-    split_parms:
-        __current_case__: 6
-        input:
-            __class__: ConnectedValue
-        newfilenames: meta_var_
-        select_allocate:
-            __current_case__: 2
-            allocate: byrow
-        select_ftype: generic
-        select_mode:
-            __current_case__: 0
-            chunksize: '1'
-            mode: chunk
-        split_method:
-            __current_case__: 1
-            record_length: '1'
-            select_split_method: number

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -95,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_VARIABLE
+    batch_key: BATCH_FIELD
     input_format: anndata
     output_format: anndata_h5ad
     settings:

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -323,7 +323,7 @@ split_metadata_vars:
     split_parms:
         __current_case__: 6
         input:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         newfilenames: meta_var_
         select_allocate:
             __current_case__: 2

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -324,7 +324,7 @@ split_metadata_vars:
         __current_case__: 6
         input:
             __class__: RuntimeValue
-        newfilenames: split_file
+        newfilenames: meta_var_
         select_allocate:
             __current_case__: 2
             allocate: byrow

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -95,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_FIELD
+    batch_key: BATCH_VARIABLE
     input_format: anndata
     output_format: anndata_h5ad
     settings:
@@ -160,6 +160,7 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
+metadata_group_vars: {}
 n_neighbors:
     input_type:
         __current_case__: 0
@@ -318,11 +319,21 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
-specify_celltype_field:
-    token_set:
-    -   __index__: 0
-        line: CELL_TYPE_FIELD
-        repeat_select:
+split_metadata_vars:
+    split_parms:
+        __current_case__: 6
+        input:
+            __class__: RuntimeValue
+        newfilenames: split_file
+        select_allocate:
+            __current_case__: 2
+            allocate: byrow
+        select_ftype: generic
+        select_mode:
             __current_case__: 0
-            repeat_select_opts: user
-            times: '1'
+            chunksize: '1'
+            mode: chunk
+        split_method:
+            __current_case__: 1
+            record_length: '1'
+            select_split_method: number

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -1,7 +1,11 @@
-Filtered cell type marker: {}
-Filtered cluster markers: {}
+Filtered cellgroup markers: {}
 barcodes: {}
 cellmeta: {}
+clusering_slotnames:
+    replacements:
+    -   __index__: 0
+        find_pattern: (.*)
+        replace_pattern: louvain_resolution_\1
 filter_cells:
     categories: []
     export_mtx: 'true'
@@ -50,31 +54,11 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
     groupby: INPUT_OBJ
-    input_format: anndata
-    n_genes: '100'
-    output_format: anndata_h5ad
-    output_markers: 'true'
-    settings:
-        __current_case__: 1
-        default: 'false'
-        groups: ''
-        key_added: markers_GROUPBY
-        max_out_group_fraction: '1.0'
-        method: t-test_overestim_var
-        min_fold_change: '1.0'
-        min_in_group_fraction: '0.0'
-        pts: 'false'
-        rankby_abs: 'false'
-        reference: rest
-        tie_correct: 'false'
-        use_raw: 'true'
-find_markers_cell_type:
-    groupby: CELL_TYPE_FIELD
     input_format: anndata
     n_genes: '100'
     output_format: anndata_h5ad
@@ -111,7 +95,7 @@ gtf: {}
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
-    batch_key: BATCH_FIELD
+    batch_key: BATCH_VARIABLE
     input_format: anndata
     output_format: anndata_h5ad
     settings:
@@ -152,7 +136,7 @@ make_project_file:
     sanitize_varm: 'false'
     top_genes: '50'
 matrix: {}
-merged_embeddings:
+merge_group_slotnames:
     advanced:
         conflict:
             __current_case__: 3
@@ -164,7 +148,7 @@ merged_embeddings:
     -   __index__: 1
         input:
             __class__: ConnectedValue
-merged_markers:
+merged_embeddings:
     advanced:
         conflict:
             __current_case__: 3
@@ -334,3 +318,11 @@ run_umap:
         random_seed: '0'
         spread: '1.0'
     use_graph: neighbors_INPUT_OBJ
+specify_celltype_field:
+    token_set:
+    -   __index__: 0
+        line: CELL_TYPE_FIELD
+        repeat_select:
+            __current_case__: 0
+            repeat_select_opts: user
+            times: '1'


### PR DESCRIPTION
This PR addresses an issue discovered with the last workflow update in https://github.com/ebi-gene-expression-group/scxa-workflows/pull/20. In assembling the project object, we handled the cell type and cluster markers separately, but when the cell type markers step fails (which it does by design), it prevents progression of the rest of the workflow. 

In this revision, cluster and cell type markers are handled as part of the same collection, taking the clustering slot from a file object rather than the standard field (previously used for cell types) or the output file name of the upstream step (previously used by the unsupervised clusterings). Because a single collection is now produced for markers, we can use a Galaxy tool for filtering failed processes (for either clusters or cell types) without halting the workflow as a whole. 

This required metadata parameter files to be named correctly so that those names could be used correctly in saving files downstream, which is harder than it sounds in Galaxy. In the end I improved https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/pull/203 to allow production of metadata parameter files with the right naming. 

This will require paired alterations to https://github.com/ebi-gene-expression-group/scxa-control-workflow/blob/develop/bin/submitTertiaryWorkflow.sh (see https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/26) and to bundling (see https://github.com/ebi-gene-expression-group/scxa-bundle-workflow/pull/10), but I think it's overall a neater structure.

The new workflow can be reviewed at http://galaxy-gxa-001:8089/u/jmanning/w/scanpy-prod-160-clustering-with-harmony-batch-adjustment-h5ad---groupby-as-file.

**Note:** I have checked that collection ordering is retained for e.g. the list of resolution values through the clusterings, which allows this change to work. 