### PR TITLE
Feature/improved matrix handling

### DIFF
--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -3,7 +3,7 @@ barcodes:
     optional: false
 cellmeta:
     optional: false
-clusering_slotnames:
+clustering_slotnames:
     replacements:
     -   __index__: 0
         find_pattern: (.*)
@@ -40,7 +40,7 @@ filter_genes:
     -   __index__: 0
         name: index
         subset:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 find_clusters:
     input_format: anndata
     method: louvain
@@ -56,7 +56,7 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
@@ -165,10 +165,10 @@ merge_group_slotnames:
     inputs:
     -   __index__: 0
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
     -   __index__: 1
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 merged_embeddings:
     advanced:
         conflict:
@@ -221,7 +221,7 @@ neighbours for umap:
         metric: euclidean
         n_neighbors: '15'
         n_neighbors_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         n_pcs: '50'
         random_seed: '0'
         use_rep: X_pca
@@ -303,7 +303,7 @@ run_tsne:
         n_pc: ''
         perplexity: '30.0'
         perplexity_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         random_seed: '1234'
     use_rep: auto
 run_umap:

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -268,29 +268,6 @@ perplexity:
         input_values: 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50
         parameter_values: list_comma_separated_values
     parameter_name: perplexity
-plot_pca:
-    basis: pca
-    color_by: n_genes
-    components: ''
-    edges: 'false'
-    edges_color: ''
-    edges_width: '0.1'
-    fig_dpi: '80'
-    fig_fontsize: '10'
-    fig_frame: 'false'
-    fig_size: 7,7
-    fig_title: PCA
-    gene_symbols_field: ''
-    groups: ''
-    input_format: anndata
-    layer: ''
-    legend_fontsize: '10'
-    legend_loc: right margin
-    neighbors_key: ''
-    point_size: ''
-    projection: 2d
-    sort_order: 'false'
-    use_raw: 'true'
 resolution:
     __job_resource:
         __current_case__: 0

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -1,6 +1,8 @@
 Filtered cellgroup markers: {}
-barcodes: {}
-cellmeta: {}
+barcodes:
+    optional: false
+cellmeta:
+    optional: false
 clusering_slotnames:
     replacements:
     -   __index__: 0
@@ -90,8 +92,10 @@ find_variable_genes:
     n_top_gene: ''
     output_format: anndata_h5ad
     span: '0.3'
-genes: {}
-gtf: {}
+genes:
+    optional: false
+gtf:
+    optional: false
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
@@ -113,6 +117,9 @@ make_project_file:
             contains: umap
         embedding_sources:
             __class__: ConnectedValue
+    copy_l:
+        __current_case__: 1
+        default: 'false'
     copy_o:
         __current_case__: 0
         default: 'true'
@@ -120,6 +127,11 @@ make_project_file:
         -   __index__: 0
             contains: louvain
         obs_sources:
+            __class__: ConnectedValue
+    copy_r:
+        __current_case__: 0
+        default: 'true'
+        r_source:
             __class__: ConnectedValue
     copy_u:
         __current_case__: 0
@@ -129,13 +141,22 @@ make_project_file:
             contains: marker
         uns_sources:
             __class__: ConnectedValue
+    copy_x:
+        __current_case__: 0
+        default: 'true'
+        xlayers:
+        -   __index__: 0
+            dest: filtered
+            x_source:
+                __class__: ConnectedValue
     gene_flags: []
     gene_symbols_field: index
     modifications: []
     output_format: anndata_h5ad
     sanitize_varm: 'false'
     top_genes: '50'
-matrix: {}
+matrix:
+    optional: false
 merge_group_slotnames:
     advanced:
         conflict:
@@ -218,7 +239,6 @@ normalise_data:
         layer_norm: ''
         layers: ''
         log_transform: 'false'
-        save_raw: 'true'
         scale_factor: '1000000.0'
 normalise_data_internal:
     export_mtx: 'false'
@@ -234,8 +254,7 @@ normalise_data_internal:
         layer_norm: ''
         layers: ''
         log_transform: 'true'
-        save_raw: 'true'
-        scale_factor: '10000.0'
+        scale_factor: '1000000.0'
 perplexity:
     __job_resource:
         __current_case__: 0
@@ -280,7 +299,7 @@ resolution:
 run_pca:
     extra_outputs: null
     input_format: anndata
-    n_pcs: '50'
+    n_pcs: ''
     output_format: anndata_h5ad
     run_mode:
         __current_case__: 1

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -40,7 +40,7 @@ filter_genes:
     -   __index__: 0
         name: index
         subset:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
 find_clusters:
     input_format: anndata
     method: louvain
@@ -56,7 +56,7 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
@@ -177,10 +177,10 @@ merged_embeddings:
     inputs:
     -   __index__: 0
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
     -   __index__: 1
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 meta_vars:
     input_type:
         __current_case__: 0
@@ -221,7 +221,7 @@ neighbours for umap:
         metric: euclidean
         n_neighbors: '15'
         n_neighbors_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         n_pcs: '50'
         random_seed: '0'
         use_rep: X_pca
@@ -303,7 +303,7 @@ run_tsne:
         n_pc: ''
         perplexity: '30.0'
         perplexity_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         random_seed: '1234'
     use_rep: auto
 run_umap:

--- a/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_droplet_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -229,6 +229,8 @@ normalise_data:
     export_mtx: 'true'
     input_format: anndata
     output_format: anndata_h5ad
+    save_layer: ''
+    save_raw: 'false'
     settings:
         __current_case__: 1
         default: 'false'
@@ -244,6 +246,8 @@ normalise_data_internal:
     export_mtx: 'false'
     input_format: anndata
     output_format: anndata_h5ad
+    save_layer: ''
+    save_raw: 'false'
     settings:
         __current_case__: 1
         default: 'false'

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -13,32 +13,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "barcodes"
+                    "name": "cellmeta"
                 }
             ],
-            "label": "barcodes",
+            "label": "cellmeta",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 96.5,
+                "bottom": 51,
                 "height": 61,
-                "left": -729.5,
-                "right": -529.5,
-                "top": 35.5,
+                "left": -649.5,
+                "right": -449.5,
+                "top": -10,
                 "width": 200,
-                "x": -729.5,
-                "y": 35.5
+                "x": -649.5,
+                "y": -10
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
+            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "362edaae-5b4f-4f97-b03c-f29aa6a63878"
+                    "uuid": "f4cce2c2-23a7-4b34-8e27-f2abd4db0dec"
                 }
             ]
         },
@@ -51,32 +51,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "cellmeta"
+                    "name": "matrix"
                 }
             ],
-            "label": "cellmeta",
+            "label": "matrix",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 195.5,
+                "bottom": 150,
                 "height": 61,
-                "left": -729.5,
-                "right": -529.5,
-                "top": 134.5,
+                "left": -649.5,
+                "right": -449.5,
+                "top": 89,
                 "width": 200,
-                "x": -729.5,
-                "y": 134.5
+                "x": -649.5,
+                "y": 89
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
+            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "1bf13ed9-e246-492a-9b04-cbcff7427aaf"
+                    "uuid": "f8485ce8-6cb5-492b-bcbe-ff68a2682daa"
                 }
             ]
         },
@@ -89,32 +89,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "matrix"
+                    "name": "barcodes"
                 }
             ],
-            "label": "matrix",
+            "label": "barcodes",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 294.5,
+                "bottom": -48,
                 "height": 61,
-                "left": -729.5,
-                "right": -529.5,
-                "top": 233.5,
+                "left": -649.5,
+                "right": -449.5,
+                "top": -109,
                 "width": 200,
-                "x": -729.5,
-                "y": 233.5
+                "x": -649.5,
+                "y": -109
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
+            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "2e1dd437-7f9b-4688-ad37-920c9ff8c668"
+                    "uuid": "2aab33fc-c24a-4105-b437-8c151ecb0aaa"
                 }
             ]
         },
@@ -134,14 +134,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 89.5,
+                "bottom": -55,
                 "height": 61,
-                "left": -1285.5,
-                "right": -1085.5,
-                "top": 28.5,
+                "left": -1205.5,
+                "right": -1005.5,
+                "top": -116,
                 "width": 200,
-                "x": -1285.5,
-                "y": 28.5
+                "x": -1205.5,
+                "y": -116
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -152,7 +152,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "a2a81673-2ce1-4280-a365-792476011657"
+                    "uuid": "0846d6ca-3046-491b-818f-63c9f33fd92c"
                 }
             ]
         },
@@ -172,14 +172,14 @@
                 }
             ],
             "position": {
-                "bottom": 773.5,
+                "bottom": 629,
                 "height": 81,
-                "left": 1216.5,
-                "right": 1416.5,
-                "top": 692.5,
+                "left": 1296.5,
+                "right": 1496.5,
+                "top": 548,
                 "width": 200,
-                "x": 1216.5,
-                "y": 692.5
+                "x": 1296.5,
+                "y": 548
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -208,9 +208,92 @@
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "content_id": null,
             "errors": null,
             "id": 5,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "gtf"
+                }
+            ],
+            "label": "gtf",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 199,
+                "height": 61,
+                "left": -1483.5,
+                "right": -1283.5,
+                "top": 138,
+                "width": 200,
+                "x": -1483.5,
+                "y": 138
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "5c96ad77-57e0-4f62-b885-0251e0907dca"
+                }
+            ]
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "errors": null,
+            "id": 6,
+            "input_connections": {},
+            "inputs": [],
+            "label": "n_neighbors",
+            "name": "Scanpy ParameterIterator",
+            "outputs": [
+                {
+                    "name": "parameter_iteration",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 991,
+                "height": 81,
+                "left": 1296.5,
+                "right": 1496.5,
+                "top": 910,
+                "width": 200,
+                "x": 1296.5,
+                "y": 910
+            },
+            "post_job_actions": {
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "fb354a78d4ae",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy2",
+            "type": "tool",
+            "uuid": "5e22d4cd-71d6-4a91-b326-508494138b82",
+            "workflow_outputs": []
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "errors": null,
+            "id": 7,
             "input_connections": {},
             "inputs": [],
             "label": "resolution",
@@ -222,14 +305,14 @@
                 }
             ],
             "position": {
-                "bottom": 549.5,
+                "bottom": 405,
                 "height": 81,
-                "left": 1494.5,
-                "right": 1694.5,
-                "top": 468.5,
+                "left": 1574.5,
+                "right": 1774.5,
+                "top": 324,
                 "width": 200,
-                "x": 1494.5,
-                "y": 468.5
+                "x": 1574.5,
+                "y": 324
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -256,89 +339,6 @@
             "uuid": "4b596e78-fbaa-423a-9a66-f696600ad75b",
             "workflow_outputs": []
         },
-        "6": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 6,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "gtf"
-                }
-            ],
-            "label": "gtf",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 343.5,
-                "height": 61,
-                "left": -1563.5,
-                "right": -1363.5,
-                "top": 282.5,
-                "width": 200,
-                "x": -1563.5,
-                "y": 282.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "9309b751-9459-4d25-9897-f7fb10dbe3ff"
-                }
-            ]
-        },
-        "7": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
-            "errors": null,
-            "id": 7,
-            "input_connections": {},
-            "inputs": [],
-            "label": "n_neighbors",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
-                {
-                    "name": "parameter_iteration",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 1135.5,
-                "height": 81,
-                "left": 1216.5,
-                "right": 1416.5,
-                "top": 1054.5,
-                "width": 200,
-                "x": 1216.5,
-                "y": 1054.5
-            },
-            "post_job_actions": {
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "fb354a78d4ae",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy2",
-            "type": "tool",
-            "uuid": "5e22d4cd-71d6-4a91-b326-508494138b82",
-            "workflow_outputs": []
-        },
         "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
@@ -355,14 +355,14 @@
                 }
             ],
             "position": {
-                "bottom": 749.5,
+                "bottom": 605,
                 "height": 81,
-                "left": 1782.5,
-                "right": 1982.5,
-                "top": 668.5,
+                "left": 1862.5,
+                "right": 2062.5,
+                "top": 524,
                 "width": 200,
-                "x": 1782.5,
-                "y": 668.5
+                "x": 1862.5,
+                "y": 524
             },
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -386,69 +386,12 @@
         },
         "9": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
             "id": 9,
             "input_connections": {
-                "infile": {
-                    "id": 5,
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "inputs": [],
-            "label": "clusering_slotnames",
-            "name": "Replace Text",
-            "outputs": [
-                {
-                    "name": "outfile",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 899.5,
-                "height": 112,
-                "left": 1782.5,
-                "right": 1982.5,
-                "top": 787.5,
-                "width": 200,
-                "x": 1782.5,
-                "y": 787.5
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "outfile"
-                },
-                "RenameDatasetActionoutfile": {
-                    "action_arguments": {
-                        "newname": "#{infile}"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
-            "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.2",
-            "type": "tool",
-            "uuid": "2c325236-8140-4904-9a72-5a037f7484b8",
-            "workflow_outputs": []
-        },
-        "10": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "errors": null,
-            "id": 10,
-            "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
@@ -462,14 +405,14 @@
                 }
             ],
             "position": {
-                "bottom": 379.5,
+                "bottom": 235,
                 "height": 132,
-                "left": -1007.5,
-                "right": -807.5,
-                "top": 247.5,
+                "left": -927.5,
+                "right": -727.5,
+                "top": 103,
                 "width": 200,
-                "x": -1007.5,
-                "y": 247.5
+                "x": -927.5,
+                "y": 103
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -498,14 +441,14 @@
             "uuid": "5c0d8c50-7891-4dc6-826f-0e5a6d3117bb",
             "workflow_outputs": []
         },
-        "11": {
+        "10": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
-            "id": 11,
+            "id": 10,
             "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
@@ -519,14 +462,14 @@
                 }
             ],
             "position": {
-                "bottom": 549.5,
+                "bottom": 405,
                 "height": 132,
-                "left": -1007.5,
-                "right": -807.5,
-                "top": 417.5,
+                "left": -927.5,
+                "right": -727.5,
+                "top": 273,
                 "width": 200,
-                "x": -1007.5,
-                "y": 417.5
+                "x": -927.5,
+                "y": 273
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -555,14 +498,14 @@
             "uuid": "a341aa66-f857-49b2-9614-a7231237d5ce",
             "workflow_outputs": []
         },
-        "12": {
+        "11": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
-            "id": 12,
+            "id": 11,
             "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
@@ -576,14 +519,14 @@
                 }
             ],
             "position": {
-                "bottom": -9.5,
+                "bottom": -154,
                 "height": 132,
-                "left": -1285.5,
-                "right": -1085.5,
-                "top": -141.5,
+                "left": -1205.5,
+                "right": -1005.5,
+                "top": -286,
                 "width": 200,
-                "x": -1285.5,
-                "y": -141.5
+                "x": -1205.5,
+                "y": -286
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -612,14 +555,119 @@
             "uuid": "d14f7483-6bbb-4262-a1b1-2d8bb09457d7",
             "workflow_outputs": []
         },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "infile": {
+                    "id": 7,
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "inputs": [],
+            "label": "clusering_slotnames",
+            "name": "Replace Text",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 755,
+                "height": 112,
+                "left": 1862.5,
+                "right": 2062.5,
+                "top": 643,
+                "width": 200,
+                "x": 1862.5,
+                "y": 643
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                },
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "#{infile}"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "ddf54b12c295",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.2",
+            "type": "tool",
+            "uuid": "2c325236-8140-4904-9a72-5a037f7484b8",
+            "workflow_outputs": []
+        },
         "13": {
             "annotation": "",
-            "content_id": "__MERGE_COLLECTION__",
+            "content_id": "join1",
             "errors": null,
             "id": 13,
             "input_connections": {
+                "input1": {
+                    "id": 3,
+                    "output_name": "output"
+                },
+                "input2": {
+                    "id": 11,
+                    "output_name": "feature_annotation"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join two Datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": -122,
+                "height": 142,
+                "left": -927.5,
+                "right": -727.5,
+                "top": -264,
+                "width": 200,
+                "x": -927.5,
+                "y": -264
+            },
+            "post_job_actions": {},
+            "tool_id": "join1",
+            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.3",
+            "type": "tool",
+            "uuid": "9ee16d67-bbd0-4b40-ba61-dcc6b12c75d2",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "35396344-fc2f-41f6-a9cc-7e2d3726c45c"
+                }
+            ]
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "__MERGE_COLLECTION__",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
                 "inputs_0|input": {
-                    "id": 9,
+                    "id": 12,
                     "output_name": "outfile"
                 },
                 "inputs_1|input": {
@@ -637,14 +685,14 @@
                 }
             ],
             "position": {
-                "bottom": 824.5,
+                "bottom": 680,
                 "height": 202,
-                "left": 2060.5,
-                "right": 2260.5,
-                "top": 622.5,
+                "left": 2140.5,
+                "right": 2340.5,
+                "top": 478,
                 "width": 200,
-                "x": 2060.5,
-                "y": 622.5
+                "x": 2140.5,
+                "y": 478
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -660,54 +708,6 @@
             "uuid": "ba78a440-74fd-4fe1-972e-69004ee2186f",
             "workflow_outputs": []
         },
-        "14": {
-            "annotation": "",
-            "content_id": "join1",
-            "errors": null,
-            "id": 14,
-            "input_connections": {
-                "input1": {
-                    "id": 3,
-                    "output_name": "output"
-                },
-                "input2": {
-                    "id": 12,
-                    "output_name": "feature_annotation"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Join two Datasets",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 22.5,
-                "height": 142,
-                "left": -1007.5,
-                "right": -807.5,
-                "top": -119.5,
-                "width": 200,
-                "x": -1007.5,
-                "y": -119.5
-            },
-            "post_job_actions": {},
-            "tool_id": "join1",
-            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.3",
-            "type": "tool",
-            "uuid": "9ee16d67-bbd0-4b40-ba61-dcc6b12c75d2",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "41747367-9d98-4eb7-bcf6-9325f090ffd8"
-                }
-            ]
-        },
         "15": {
             "annotation": "",
             "content_id": "Cut1",
@@ -715,7 +715,7 @@
             "id": 15,
             "input_connections": {
                 "input": {
-                    "id": 14,
+                    "id": 13,
                     "output_name": "out_file1"
                 }
             },
@@ -729,14 +729,14 @@
                 }
             ],
             "position": {
-                "bottom": -2.5,
+                "bottom": -147,
                 "height": 92,
-                "left": -729.5,
-                "right": -529.5,
-                "top": -94.5,
+                "left": -649.5,
+                "right": -449.5,
+                "top": -239,
                 "width": 200,
-                "x": -729.5,
-                "y": -94.5
+                "x": -649.5,
+                "y": -239
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
@@ -748,7 +748,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "6b456bfd-e198-410b-8cbc-37c6bf629811"
+                    "uuid": "ae458424-e137-4750-a62e-951799b25028"
                 }
             ]
         },
@@ -759,15 +759,15 @@
             "id": 16,
             "input_connections": {
                 "barcodes": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "cell_meta": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 },
                 "gene_meta": {
-                    "id": 10,
+                    "id": 9,
                     "output_name": "feature_annotation"
                 },
                 "genes": {
@@ -775,7 +775,7 @@
                     "output_name": "out_file1"
                 },
                 "matrix": {
-                    "id": 2,
+                    "id": 1,
                     "output_name": "output"
                 }
             },
@@ -789,14 +789,14 @@
                 }
             ],
             "position": {
-                "bottom": 311.5,
+                "bottom": 167,
                 "height": 292,
-                "left": -451.5,
-                "right": -251.5,
-                "top": 19.5,
+                "left": -371.5,
+                "right": -171.5,
+                "top": -125,
                 "width": 200,
-                "x": -451.5,
-                "y": 19.5
+                "x": -371.5,
+                "y": -125
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -863,14 +863,14 @@
                 }
             ],
             "position": {
-                "bottom": 460.5,
+                "bottom": 316,
                 "height": 362,
-                "left": -173.5,
-                "right": 26.5,
-                "top": 98.5,
+                "left": -93.5,
+                "right": 106.5,
+                "top": -46,
                 "width": 200,
-                "x": -173.5,
-                "y": 98.5
+                "x": -93.5,
+                "y": -46
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -923,7 +923,7 @@
                     "output_name": "output_h5ad"
                 },
                 "subsets_0|subset": {
-                    "id": 11,
+                    "id": 10,
                     "output_name": "feature_annotation"
                 }
             },
@@ -949,14 +949,14 @@
                 }
             ],
             "position": {
-                "bottom": 774.5,
+                "bottom": 630,
                 "height": 432,
-                "left": 104.5,
-                "right": 304.5,
-                "top": 342.5,
+                "left": 184.5,
+                "right": 384.5,
+                "top": 198,
                 "width": 200,
-                "x": 104.5,
-                "y": 342.5
+                "x": 184.5,
+                "y": 198
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1006,17 +1006,17 @@
                 {
                     "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "db80fe93-14e2-4e62-ae51-55e0a474377d"
+                    "uuid": "6b7d96f6-dc79-4501-b7b4-69cf6be9761d"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "532218f0-cc38-4700-b55d-8f75c7af474b"
+                    "uuid": "632aa28d-b641-483a-b9f0-a43ac36dbd8c"
                 },
                 {
                     "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "e25b1488-d152-4f78-b541-ee3a575fb347"
+                    "uuid": "dedb6146-8cc3-4983-a88b-ff63b0bcaefe"
                 }
             ]
         },
@@ -1031,12 +1031,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy NormaliseData",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "normalise_data",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1058,14 +1053,14 @@
                 }
             ],
             "position": {
-                "bottom": 424.5,
+                "bottom": 280,
                 "height": 382,
-                "left": 382.5,
-                "right": 582.5,
-                "top": 42.5,
+                "left": 462.5,
+                "right": 662.5,
+                "top": -102,
                 "width": 200,
-                "x": 382.5,
-                "y": 42.5
+                "x": 462.5,
+                "y": -102
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1102,25 +1097,25 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "1233d97d-615f-4276-a0ce-fdb36ed06fe2",
+            "uuid": "6ae16265-70c0-42e1-92f0-8a62dfef9dc8",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "matrix_10x",
-                    "uuid": "3522a3ff-04ae-4984-b2f6-68942581aa64"
-                },
-                {
-                    "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "f295a290-a9ea-43c5-bd01-9eb8cae77ec0"
+                    "uuid": "3b15d77d-2a2b-472b-b450-aca8f54f45f1"
                 },
                 {
                     "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "d5595cf0-8991-47c3-9614-98cfc5e7d0ce"
+                    "uuid": "a21bdef9-8e4e-43dd-9650-a42d1237539b"
+                },
+                {
+                    "label": null,
+                    "output_name": "matrix_10x",
+                    "uuid": "e56049fa-087a-4f8a-bd0d-e1c2ab7107f0"
                 }
             ]
         },
@@ -1150,14 +1145,14 @@
                 }
             ],
             "position": {
-                "bottom": 654.5,
+                "bottom": 510,
                 "height": 192,
-                "left": 382.5,
-                "right": 582.5,
-                "top": 462.5,
+                "left": 462.5,
+                "right": 662.5,
+                "top": 318,
                 "width": 200,
-                "x": 382.5,
-                "y": 462.5
+                "x": 462.5,
+                "y": 318
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1173,10 +1168,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "d80c5460-9eb4-43b0-a2b3-e3ee1703830a",
+            "uuid": "115fd89d-67e2-4256-91df-a056a03c16a0",
             "workflow_outputs": []
         },
         "21": {
@@ -1200,14 +1195,14 @@
                 }
             ],
             "position": {
-                "bottom": 654.5,
+                "bottom": 510,
                 "height": 192,
-                "left": 660.5,
-                "right": 860.5,
-                "top": 462.5,
+                "left": 740.5,
+                "right": 940.5,
+                "top": 318,
                 "width": 200,
-                "x": 660.5,
-                "y": 462.5
+                "x": 740.5,
+                "y": 318
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1255,14 +1250,14 @@
                 }
             ],
             "position": {
-                "bottom": 634.5,
+                "bottom": 490,
                 "height": 152,
-                "left": 938.5,
-                "right": 1138.5,
-                "top": 482.5,
+                "left": 1018.5,
+                "right": 1218.5,
+                "top": 338,
                 "width": 200,
-                "x": 938.5,
-                "y": 482.5
+                "x": 1018.5,
+                "y": 338
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1305,14 +1300,14 @@
                 }
             ],
             "position": {
-                "bottom": 654.5,
+                "bottom": 510,
                 "height": 192,
-                "left": 1216.5,
-                "right": 1416.5,
-                "top": 462.5,
+                "left": 1296.5,
+                "right": 1496.5,
+                "top": 318,
                 "width": 200,
-                "x": 1216.5,
-                "y": 462.5
+                "x": 1296.5,
+                "y": 318
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1336,59 +1331,9 @@
         },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "errors": null,
-            "id": 24,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 23,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [],
-            "label": "plot_pca",
-            "name": "Scanpy PlotEmbed",
-            "outputs": [
-                {
-                    "name": "output_png",
-                    "type": "png"
-                }
-            ],
-            "position": {
-                "bottom": 150.5,
-                "height": 152,
-                "left": 1494.5,
-                "right": 1694.5,
-                "top": -1.5,
-                "width": 200,
-                "x": 1494.5,
-                "y": -1.5
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_png"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "a8ef4bc35839",
-                "name": "scanpy_plot_embed",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"basis\": \"pca\", \"color_by\": \"n_genes\", \"components\": \"\", \"edges\": \"false\", \"edges_color\": \"\", \"edges_width\": \"0.1\", \"fig_dpi\": \"80\", \"fig_fontsize\": \"10\", \"fig_frame\": \"false\", \"fig_size\": \"7,7\", \"fig_title\": \"PCA\", \"gene_symbols_field\": \"\", \"groups\": \"\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"layer\": \"\", \"legend_fontsize\": \"10\", \"legend_loc\": \"right margin\", \"neighbors_key\": \"\", \"point_size\": \"\", \"projection\": \"2d\", \"sort_order\": \"false\", \"use_raw\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy0",
-            "type": "tool",
-            "uuid": "f9bd31d8-5eb9-450f-8d0b-cc422c9ffb80",
-            "workflow_outputs": []
-        },
-        "25": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
             "errors": null,
-            "id": 25,
+            "id": 24,
             "input_connections": {
                 "input_obj_file": {
                     "id": 23,
@@ -1410,14 +1355,14 @@
                 }
             ],
             "position": {
-                "bottom": 430.5,
+                "bottom": 286,
                 "height": 242,
-                "left": 1494.5,
-                "right": 1694.5,
-                "top": 188.5,
+                "left": 1574.5,
+                "right": 1774.5,
+                "top": 44,
                 "width": 200,
-                "x": 1494.5,
-                "y": 188.5
+                "x": 1574.5,
+                "y": 44
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1437,6 +1382,56 @@
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
             "uuid": "b3ccf81f-9897-4fa1-ac29-f8152d608c0e",
+            "workflow_outputs": []
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 23,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [],
+            "label": "plot_pca",
+            "name": "Scanpy PlotEmbed",
+            "outputs": [
+                {
+                    "name": "output_png",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "bottom": 6,
+                "height": 152,
+                "left": 1574.5,
+                "right": 1774.5,
+                "top": -146,
+                "width": 200,
+                "x": 1574.5,
+                "y": -146
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_png": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_png"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "a8ef4bc35839",
+                "name": "scanpy_plot_embed",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"basis\": \"pca\", \"color_by\": \"n_genes\", \"components\": \"\", \"edges\": \"false\", \"edges_color\": \"\", \"edges_width\": \"0.1\", \"fig_dpi\": \"80\", \"fig_fontsize\": \"10\", \"fig_frame\": \"false\", \"fig_size\": \"7,7\", \"fig_title\": \"PCA\", \"gene_symbols_field\": \"\", \"groups\": \"\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"layer\": \"\", \"legend_fontsize\": \"10\", \"legend_loc\": \"right margin\", \"neighbors_key\": \"\", \"point_size\": \"\", \"projection\": \"2d\", \"sort_order\": \"false\", \"use_raw\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.6.0+galaxy0",
+            "type": "tool",
+            "uuid": "f9bd31d8-5eb9-450f-8d0b-cc422c9ffb80",
             "workflow_outputs": []
         },
         "26": {
@@ -1468,14 +1463,14 @@
                 }
             ],
             "position": {
-                "bottom": 879.5,
+                "bottom": 735,
                 "height": 292,
-                "left": 1494.5,
-                "right": 1694.5,
-                "top": 587.5,
+                "left": 1574.5,
+                "right": 1774.5,
+                "top": 443,
                 "width": 200,
-                "x": 1494.5,
-                "y": 587.5
+                "x": 1574.5,
+                "y": 443
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1513,7 +1508,7 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "6533e066-baa5-49f8-b43e-1f6d1e2cacdb"
+                    "uuid": "ed1dd9d6-ef2c-4b0e-beb4-86cdab238902"
                 }
             ]
         },
@@ -1528,7 +1523,7 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|n_neighbors_file": {
-                    "id": 7,
+                    "id": 6,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -1542,14 +1537,14 @@
                 }
             ],
             "position": {
-                "bottom": 1179.5,
+                "bottom": 1035,
                 "height": 262,
-                "left": 1494.5,
-                "right": 1694.5,
-                "top": 917.5,
+                "left": 1574.5,
+                "right": 1774.5,
+                "top": 773,
                 "width": 200,
-                "x": 1494.5,
-                "y": 917.5
+                "x": 1574.5,
+                "y": 773
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1585,7 +1580,7 @@
             "id": 28,
             "input_connections": {
                 "datasets_0|input": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "output_h5ad"
                 }
             },
@@ -1599,14 +1594,14 @@
                 }
             ],
             "position": {
-                "bottom": 280.5,
+                "bottom": 136,
                 "height": 112,
-                "left": 1782.5,
-                "right": 1982.5,
-                "top": 168.5,
+                "left": 1862.5,
+                "right": 2062.5,
+                "top": 24,
                 "width": 200,
-                "x": 1782.5,
-                "y": 168.5
+                "x": 1862.5,
+                "y": 24
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1629,11 +1624,11 @@
             "id": 29,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "output_h5ad"
                 },
                 "settings|resolution_file": {
-                    "id": 5,
+                    "id": 7,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -1651,14 +1646,14 @@
                 }
             ],
             "position": {
-                "bottom": 630.5,
+                "bottom": 486,
                 "height": 312,
-                "left": 1782.5,
-                "right": 1982.5,
-                "top": 318.5,
+                "left": 1862.5,
+                "right": 2062.5,
+                "top": 174,
                 "width": 200,
-                "x": 1782.5,
-                "y": 318.5
+                "x": 1862.5,
+                "y": 174
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1696,7 +1691,7 @@
                 {
                     "label": null,
                     "output_name": "output_txt",
-                    "uuid": "b2518660-2b6c-48bd-a746-81bb218ba819"
+                    "uuid": "96b68a17-f405-4fe5-929a-bc5abd95ee33"
                 }
             ]
         },
@@ -1721,14 +1716,14 @@
                 }
             ],
             "position": {
-                "bottom": 974.5,
+                "bottom": 830,
                 "height": 112,
-                "left": 2060.5,
-                "right": 2260.5,
-                "top": 862.5,
+                "left": 2140.5,
+                "right": 2340.5,
+                "top": 718,
                 "width": 200,
-                "x": 2060.5,
-                "y": 862.5
+                "x": 2140.5,
+                "y": 718
             },
             "post_job_actions": {},
             "tool_id": "__FILTER_FAILED_DATASETS__",
@@ -1740,7 +1735,7 @@
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "b2becc55-53e1-443e-8c29-95cb79d13faa"
+                    "uuid": "d129f474-8c05-4d5e-8e8f-0a021c406ba0"
                 }
             ]
         },
@@ -1769,14 +1764,14 @@
                 }
             ],
             "position": {
-                "bottom": 1179.5,
+                "bottom": 1035,
                 "height": 222,
-                "left": 1782.5,
-                "right": 1982.5,
-                "top": 957.5,
+                "left": 1862.5,
+                "right": 2062.5,
+                "top": 813,
                 "width": 200,
-                "x": 1782.5,
-                "y": 957.5
+                "x": 1862.5,
+                "y": 813
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1812,7 +1807,7 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "0e6c6e8d-f43c-43e7-87bd-627ed4bbf82b"
+                    "uuid": "4b0b21b9-741d-4c89-a7da-189db65b890a"
                 }
             ]
         },
@@ -1841,14 +1836,14 @@
                 }
             ],
             "position": {
-                "bottom": 538.5,
+                "bottom": 394,
                 "height": 202,
-                "left": 2060.5,
-                "right": 2260.5,
-                "top": 336.5,
+                "left": 2140.5,
+                "right": 2340.5,
+                "top": 192,
                 "width": 200,
-                "x": 2060.5,
-                "y": 336.5
+                "x": 2140.5,
+                "y": 192
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1885,14 +1880,14 @@
                 }
             ],
             "position": {
-                "bottom": 1124.5,
+                "bottom": 980,
                 "height": 112,
-                "left": 2060.5,
-                "right": 2260.5,
-                "top": 1012.5,
+                "left": 2140.5,
+                "right": 2340.5,
+                "top": 868,
                 "width": 200,
-                "x": 2060.5,
-                "y": 1012.5
+                "x": 2140.5,
+                "y": 868
             },
             "post_job_actions": {},
             "tool_id": "__FILTER_FAILED_DATASETS__",
@@ -1904,7 +1899,7 @@
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "e3d27964-869a-4b9a-b3df-f409f40fc6d4"
+                    "uuid": "a5f2e4e0-2681-4515-a522-ccea0b347507"
                 }
             ]
         },
@@ -1915,7 +1910,7 @@
             "id": 34,
             "input_connections": {
                 "groupby_file": {
-                    "id": 13,
+                    "id": 14,
                     "output_name": "output"
                 },
                 "input_obj_file": {
@@ -1937,14 +1932,14 @@
                 }
             ],
             "position": {
-                "bottom": 660.5,
+                "bottom": 516,
                 "height": 292,
-                "left": 2338.5,
-                "right": 2538.5,
-                "top": 368.5,
+                "left": 2418.5,
+                "right": 2618.5,
+                "top": 224,
                 "width": 200,
-                "x": 2338.5,
-                "y": 368.5
+                "x": 2418.5,
+                "y": 224
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1975,7 +1970,7 @@
                 {
                     "label": null,
                     "output_name": "output_tsv",
-                    "uuid": "9c6b1b69-f80c-4bfe-a845-21caf3ea56ac"
+                    "uuid": "56482e95-e7e8-42fe-b9fd-6e3c64029bc8"
                 }
             ]
         },
@@ -2004,14 +1999,14 @@
                 }
             ],
             "position": {
-                "bottom": 1132.5,
+                "bottom": 988,
                 "height": 202,
-                "left": 2338.5,
-                "right": 2538.5,
-                "top": 930.5,
+                "left": 2418.5,
+                "right": 2618.5,
+                "top": 786,
                 "width": 200,
-                "x": 2338.5,
-                "y": 930.5
+                "x": 2418.5,
+                "y": 786
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2053,14 +2048,14 @@
                 }
             ],
             "position": {
-                "bottom": 580.5,
+                "bottom": 436,
                 "height": 132,
-                "left": 2616.5,
-                "right": 2816.5,
-                "top": 448.5,
+                "left": 2696.5,
+                "right": 2896.5,
+                "top": 304,
                 "width": 200,
-                "x": 2616.5,
-                "y": 448.5
+                "x": 2696.5,
+                "y": 304
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2108,7 +2103,7 @@
                     "output_name": "output_h5ad"
                 },
                 "input_obj_file": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "output_h5ad"
                 }
             },
@@ -2122,14 +2117,14 @@
                 }
             ],
             "position": {
-                "bottom": 765.5,
+                "bottom": 621,
                 "height": 502,
-                "left": 2904.5,
-                "right": 3104.5,
-                "top": 263.5,
+                "left": 2984.5,
+                "right": 3184.5,
+                "top": 119,
                 "width": 200,
-                "x": 2904.5,
-                "y": 263.5
+                "x": 2984.5,
+                "y": 119
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -2142,7 +2137,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.7.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "e4bb4666449e",
+                "changeset_revision": "53a251c6d991",
                 "name": "anndata_ops",
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2155,12 +2150,12 @@
                 {
                     "label": null,
                     "output_name": "output_h5ad",
-                    "uuid": "a66f250f-1687-41a0-b2cc-e569beee5c9b"
+                    "uuid": "1d37666e-774a-4121-8f09-277faf4c76fb"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "1cb50341-1cbc-4e15-a8d6-71f312a806ee",
-    "version": 9
+    "uuid": "0fc26658-8d36-48e9-9a70-f3ff98242c13",
+    "version": 11
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -6,349 +6,9 @@
     "steps": {
         "0": {
             "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 0,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "gtf"
-                }
-            ],
-            "label": "gtf",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 285.5,
-                "height": 61,
-                "left": 460,
-                "right": 660,
-                "top": 224.5,
-                "width": 200,
-                "x": 460,
-                "y": 224.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "709ef392-251d-4faa-8dce-e17a42f1a275"
-                }
-            ]
-        },
-        "1": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 1,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "genes"
-                }
-            ],
-            "label": "genes",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 439.5,
-                "height": 61,
-                "left": 738,
-                "right": 938,
-                "top": 378.5,
-                "width": 200,
-                "x": 738,
-                "y": 378.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "79451756-8ed4-4600-a94b-3603b3b6d147",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "6e5f9319-ba9d-486f-bda2-d971f6ad961a"
-                }
-            ]
-        },
-        "2": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 2,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "matrix"
-                }
-            ],
-            "label": "matrix",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 422.5,
-                "height": 61,
-                "left": 1294,
-                "right": 1494,
-                "top": 361.5,
-                "width": 200,
-                "x": 1294,
-                "y": 361.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "af823244-0dbe-4f10-8f74-4ced8a2dc1b7"
-                }
-            ]
-        },
-        "3": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 3,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "cellmeta"
-                }
-            ],
-            "label": "cellmeta",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 521.5,
-                "height": 61,
-                "left": 1294,
-                "right": 1494,
-                "top": 460.5,
-                "width": 200,
-                "x": 1294,
-                "y": 460.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "44576d23-e925-4ea8-a493-b4f11844befe"
-                }
-            ]
-        },
-        "4": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 4,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "barcodes"
-                }
-            ],
-            "label": "barcodes",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 620.5,
-                "height": 61,
-                "left": 1294,
-                "right": 1494,
-                "top": 559.5,
-                "width": 200,
-                "x": 1294,
-                "y": 559.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "64a0dbb9-18d4-4384-b452-f437f5c1032a"
-                }
-            ]
-        },
-        "5": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
-            "errors": null,
-            "id": 5,
-            "input_connections": {},
-            "inputs": [],
-            "label": "perplexity",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
-                {
-                    "name": "parameter_iteration",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 428.5,
-                "height": 81,
-                "left": 3250,
-                "right": 3450,
-                "top": 347.5,
-                "width": 200,
-                "x": 3250,
-                "y": 347.5
-            },
-            "post_job_actions": {
-                "DeleteIntermediatesActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "parameter_iteration"
-                },
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "645f12f44a6d",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50\"}, \"parameter_name\": \"perplexity\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy1",
-            "type": "tool",
-            "uuid": "00700721-8faf-4f86-9d80-2daf4bebffeb",
-            "workflow_outputs": []
-        },
-        "6": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
-            "errors": null,
-            "id": 6,
-            "input_connections": {},
-            "inputs": [],
-            "label": "n_neighbors",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
-                {
-                    "name": "parameter_iteration",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 666.5,
-                "height": 81,
-                "left": 3250,
-                "right": 3450,
-                "top": 585.5,
-                "width": 200,
-                "x": 3250,
-                "y": 585.5
-            },
-            "post_job_actions": {
-                "DeleteIntermediatesActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "parameter_iteration"
-                },
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "fb354a78d4ae",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy2",
-            "type": "tool",
-            "uuid": "ca0708bd-865d-48dc-ad22-f81a8d0c2e01",
-            "workflow_outputs": []
-        },
-        "7": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
-            "errors": null,
-            "id": 7,
-            "input_connections": {},
-            "inputs": [],
-            "label": "resolution",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
-                {
-                    "name": "parameter_iteration",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 65.5,
-                "height": 81,
-                "left": 3538,
-                "right": 3738,
-                "top": -15.5,
-                "width": 200,
-                "x": 3538,
-                "y": -15.5
-            },
-            "post_job_actions": {
-                "DeleteIntermediatesActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "parameter_iteration"
-                },
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "645f12f44a6d",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0\"}, \"parameter_name\": \"resolution\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy1",
-            "type": "tool",
-            "uuid": "4b596e78-fbaa-423a-9a66-f696600ad75b",
-            "workflow_outputs": []
-        },
-        "8": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
             "errors": null,
-            "id": 8,
+            "id": 0,
             "input_connections": {},
             "inputs": [],
             "label": "meta_vars",
@@ -360,14 +20,14 @@
                 }
             ],
             "position": {
-                "bottom": 449.5,
+                "bottom": 404,
                 "height": 81,
-                "left": 3826,
-                "right": 4026,
-                "top": 368.5,
+                "left": -189.5,
+                "right": 10.5,
+                "top": 323,
                 "width": 200,
-                "x": 3826,
-                "y": 368.5
+                "x": -189.5,
+                "y": 323
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -394,224 +54,358 @@
             "uuid": "b0153814-f701-4f0a-ab1f-cee9e434e915",
             "workflow_outputs": []
         },
-        "9": {
+        "1": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
             "errors": null,
-            "id": 9,
-            "input_connections": {
-                "gtf_input": {
-                    "id": 0,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GTF2GeneList",
-                    "name": "gtf_input"
-                }
-            ],
-            "label": null,
-            "name": "GTF2GeneList",
+            "id": 1,
+            "input_connections": {},
+            "inputs": [],
+            "label": "resolution",
+            "name": "Scanpy ParameterIterator",
             "outputs": [
                 {
-                    "name": "feature_annotation",
-                    "type": "tsv"
+                    "name": "parameter_iteration",
+                    "type": "input"
                 }
             ],
             "position": {
-                "bottom": 609.5,
-                "height": 132,
-                "left": 738,
-                "right": 938,
-                "top": 477.5,
+                "bottom": 20,
+                "height": 81,
+                "left": -477.5,
+                "right": -277.5,
+                "top": -61,
                 "width": 200,
-                "x": 738,
-                "y": 477.5
+                "x": -477.5,
+                "y": -61
             },
             "post_job_actions": {
-                "ChangeDatatypeActionfeature_annotation": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "feature_annotation"
-                },
-                "DeleteIntermediatesActionfeature_annotation": {
+                "DeleteIntermediatesActionparameter_iteration": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "feature_annotation"
+                    "output_name": "parameter_iteration"
                 },
-                "HideDatasetActionfeature_annotation": {
+                "HideDatasetActionparameter_iteration": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "feature_annotation"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9",
-                "name": "gtf2gene_list",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id,gene_name\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.42.1+galaxy4",
-            "type": "tool",
-            "uuid": "a1ebb947-640a-4c27-a2a7-715170b05a4c",
-            "workflow_outputs": []
-        },
-        "10": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "errors": null,
-            "id": 10,
-            "input_connections": {
-                "gtf_input": {
-                    "id": 0,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GTF2GeneList",
-                    "name": "gtf_input"
-                }
-            ],
-            "label": null,
-            "name": "GTF2GeneList",
-            "outputs": [
-                {
-                    "name": "feature_annotation",
-                    "type": "tsv"
-                }
-            ],
-            "position": {
-                "bottom": 408.5,
-                "height": 132,
-                "left": 1016,
-                "right": 1216,
-                "top": 276.5,
-                "width": 200,
-                "x": 1016,
-                "y": 276.5
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionfeature_annotation": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "feature_annotation"
-                },
-                "DeleteIntermediatesActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "feature_annotation"
-                },
-                "HideDatasetActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "feature_annotation"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9",
-                "name": "gtf2gene_list",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.42.1+galaxy4",
-            "type": "tool",
-            "uuid": "3e5764bd-c583-47a8-9e8f-fd5f2b609705",
-            "workflow_outputs": []
-        },
-        "11": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "errors": null,
-            "id": 11,
-            "input_connections": {
-                "gtf_input": {
-                    "id": 0,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GTF2GeneList",
-                    "name": "gtf_input"
-                }
-            ],
-            "label": null,
-            "name": "GTF2GeneList",
-            "outputs": [
-                {
-                    "name": "feature_annotation",
-                    "type": "tsv"
-                }
-            ],
-            "position": {
-                "bottom": 321.5,
-                "height": 132,
-                "left": 1582,
-                "right": 1782,
-                "top": 189.5,
-                "width": 200,
-                "x": 1582,
-                "y": 189.5
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionfeature_annotation": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "feature_annotation"
-                },
-                "DeleteIntermediatesActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "feature_annotation"
-                },
-                "HideDatasetActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "feature_annotation"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9",
-                "name": "gtf2gene_list",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.42.1+galaxy4",
-            "type": "tool",
-            "uuid": "588f7d28-70ac-4ea7-b8ce-1430f334f9f2",
-            "workflow_outputs": []
-        },
-        "12": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
-            "errors": null,
-            "id": 12,
-            "input_connections": {
-                "infile": {
-                    "id": 7,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "645f12f44a6d",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0\"}, \"parameter_name\": \"resolution\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy1",
+            "type": "tool",
+            "uuid": "4b596e78-fbaa-423a-9a66-f696600ad75b",
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [],
+            "label": "perplexity",
+            "name": "Scanpy ParameterIterator",
+            "outputs": [
                 {
-                    "description": "runtime parameter for tool Replace Text",
-                    "name": "infile"
+                    "name": "parameter_iteration",
+                    "type": "input"
                 }
             ],
+            "position": {
+                "bottom": 383,
+                "height": 81,
+                "left": -765.5,
+                "right": -565.5,
+                "top": 302,
+                "width": 200,
+                "x": -765.5,
+                "y": 302
+            },
+            "post_job_actions": {
+                "DeleteIntermediatesActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "parameter_iteration"
+                },
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "645f12f44a6d",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50\"}, \"parameter_name\": \"perplexity\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy1",
+            "type": "tool",
+            "uuid": "00700721-8faf-4f86-9d80-2daf4bebffeb",
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [],
+            "label": "n_neighbors",
+            "name": "Scanpy ParameterIterator",
+            "outputs": [
+                {
+                    "name": "parameter_iteration",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 621,
+                "height": 81,
+                "left": -765.5,
+                "right": -565.5,
+                "top": 540,
+                "width": 200,
+                "x": -765.5,
+                "y": 540
+            },
+            "post_job_actions": {
+                "DeleteIntermediatesActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "parameter_iteration"
+                },
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "fb354a78d4ae",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy2",
+            "type": "tool",
+            "uuid": "ca0708bd-865d-48dc-ad22-f81a8d0c2e01",
+            "workflow_outputs": []
+        },
+        "4": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "matrix"
+                }
+            ],
+            "label": "matrix",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 377,
+                "height": 61,
+                "left": -2721.5,
+                "right": -2521.5,
+                "top": 316,
+                "width": 200,
+                "x": -2721.5,
+                "y": 316
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "23806c02-b7d9-45d6-b445-411032f84549"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 5,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "cellmeta"
+                }
+            ],
+            "label": "cellmeta",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 476,
+                "height": 61,
+                "left": -2721.5,
+                "right": -2521.5,
+                "top": 415,
+                "width": 200,
+                "x": -2721.5,
+                "y": 415
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "b055f776-8414-4a38-b5fa-274b1ac1b418"
+                }
+            ]
+        },
+        "6": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 6,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "barcodes"
+                }
+            ],
+            "label": "barcodes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 575,
+                "height": 61,
+                "left": -2721.5,
+                "right": -2521.5,
+                "top": 514,
+                "width": 200,
+                "x": -2721.5,
+                "y": 514
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "5837b42f-0573-4bfc-aa17-69eb734d73b7"
+                }
+            ]
+        },
+        "7": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 7,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "genes"
+                }
+            ],
+            "label": "genes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 394,
+                "height": 61,
+                "left": -3277.5,
+                "right": -3077.5,
+                "top": 333,
+                "width": 200,
+                "x": -3277.5,
+                "y": 333
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "79451756-8ed4-4600-a94b-3603b3b6d147",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "fff6aaca-b326-42cd-87ec-81c5eed4109e"
+                }
+            ]
+        },
+        "8": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 8,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "gtf"
+                }
+            ],
+            "label": "gtf",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 240,
+                "height": 61,
+                "left": -3555.5,
+                "right": -3355.5,
+                "top": 179,
+                "width": 200,
+                "x": -3555.5,
+                "y": 179
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "33a40179-15da-47c2-b6a2-57da1e2ea354"
+                }
+            ]
+        },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "infile": {
+                    "id": 1,
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "inputs": [],
             "label": "clustering_slotnames",
             "name": "Replace Text",
             "outputs": [
@@ -621,14 +415,14 @@
                 }
             ],
             "position": {
-                "bottom": 330.5,
+                "bottom": 285,
                 "height": 112,
-                "left": 3826,
-                "right": 4026,
-                "top": 218.5,
+                "left": -189.5,
+                "right": 10.5,
+                "top": 173,
                 "width": 200,
-                "x": 3826,
-                "y": 218.5
+                "x": -189.5,
+                "y": 173
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutfile": {
@@ -656,87 +450,210 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"infile\": {\"__class__\": \"RuntimeValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "8f5eeae2-a260-4a87-8049-6772d5412129",
             "workflow_outputs": []
         },
-        "13": {
+        "10": {
             "annotation": "",
-            "content_id": "join1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
-            "id": 13,
+            "id": 10,
             "input_connections": {
-                "input1": {
-                    "id": 1,
+                "gtf_input": {
+                    "id": 8,
                     "output_name": "output"
-                },
-                "input2": {
-                    "id": 9,
-                    "output_name": "feature_annotation"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Join two Datasets",
-                    "name": "input1"
-                },
-                {
-                    "description": "runtime parameter for tool Join two Datasets",
-                    "name": "input2"
-                }
-            ],
+            "inputs": [],
             "label": null,
-            "name": "Join two Datasets",
+            "name": "GTF2GeneList",
             "outputs": [
                 {
-                    "name": "out_file1",
-                    "type": "tabular"
+                    "name": "feature_annotation",
+                    "type": "tsv"
                 }
             ],
             "position": {
-                "bottom": 587.5,
-                "height": 142,
-                "left": 1016,
-                "right": 1216,
-                "top": 445.5,
+                "bottom": 276,
+                "height": 132,
+                "left": -2433.5,
+                "right": -2233.5,
+                "top": 144,
                 "width": 200,
-                "x": 1016,
-                "y": 445.5
+                "x": -2433.5,
+                "y": 144
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionout_file1": {
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "out_file1"
+                    "output_name": "feature_annotation"
+                },
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "feature_annotation"
                 }
             },
-            "tool_id": "join1",
-            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"RuntimeValue\"}, \"input2\": {\"__class__\": \"RuntimeValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9",
+                "name": "gtf2gene_list",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "c58555b8-032b-482d-9ef4-966421ef8f07",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "out_file1",
-                    "uuid": "f8cc259c-eaba-418b-a63a-732c7913f72b"
-                }
-            ]
+            "uuid": "588f7d28-70ac-4ea7-b8ce-1430f334f9f2",
+            "workflow_outputs": []
         },
-        "14": {
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "gtf_input": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "GTF2GeneList",
+            "outputs": [
+                {
+                    "name": "feature_annotation",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "bottom": 363,
+                "height": 132,
+                "left": -2999.5,
+                "right": -2799.5,
+                "top": 231,
+                "width": 200,
+                "x": -2999.5,
+                "y": 231
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "feature_annotation"
+                },
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "feature_annotation"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9",
+                "name": "gtf2gene_list",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.42.1+galaxy4",
+            "type": "tool",
+            "uuid": "3e5764bd-c583-47a8-9e8f-fd5f2b609705",
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "gtf_input": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "GTF2GeneList",
+            "outputs": [
+                {
+                    "name": "feature_annotation",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "bottom": 564,
+                "height": 132,
+                "left": -3277.5,
+                "right": -3077.5,
+                "top": 432,
+                "width": 200,
+                "x": -3277.5,
+                "y": 432
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "feature_annotation"
+                },
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "feature_annotation"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9",
+                "name": "gtf2gene_list",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id,gene_name\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.42.1+galaxy4",
+            "type": "tool",
+            "uuid": "a1ebb947-640a-4c27-a2a7-715170b05a4c",
+            "workflow_outputs": []
+        },
+        "13": {
             "annotation": "",
             "content_id": "__MERGE_COLLECTION__",
             "errors": null,
-            "id": 14,
+            "id": 13,
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 12,
+                    "id": 9,
                     "output_name": "outfile"
                 },
                 "inputs_1|input": {
-                    "id": 8,
+                    "id": 0,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -750,21 +667,16 @@
                 }
             ],
             "position": {
-                "bottom": 374.5,
+                "bottom": 329,
                 "height": 202,
-                "left": 4104,
-                "right": 4304,
-                "top": 172.5,
+                "left": 88.5,
+                "right": 288.5,
+                "top": 127,
                 "width": 200,
-                "x": 4104,
-                "y": 172.5
+                "x": 88.5,
+                "y": 127
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output"
-                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -775,8 +687,62 @@
             "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "9eff549e-9dfc-4573-9339-68f539ea8fa1",
+            "uuid": "a44ac947-e86c-4b32-9ca6-ba43d17fd838",
             "workflow_outputs": []
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "join1",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input1": {
+                    "id": 7,
+                    "output_name": "output"
+                },
+                "input2": {
+                    "id": 12,
+                    "output_name": "feature_annotation"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join two Datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 542,
+                "height": 142,
+                "left": -2999.5,
+                "right": -2799.5,
+                "top": 400,
+                "width": 200,
+                "x": -2999.5,
+                "y": 400
+            },
+            "post_job_actions": {
+                "DeleteIntermediatesActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "join1",
+            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.3",
+            "type": "tool",
+            "uuid": "c58555b8-032b-482d-9ef4-966421ef8f07",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "9649ebb9-8ede-4a8c-b61c-5dc6354d1a56"
+                }
+            ]
         },
         "15": {
             "annotation": "",
@@ -785,16 +751,11 @@
             "id": 15,
             "input_connections": {
                 "input": {
-                    "id": 13,
+                    "id": 14,
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Cut",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Cut",
             "outputs": [
@@ -804,14 +765,14 @@
                 }
             ],
             "position": {
-                "bottom": 750.5,
+                "bottom": 705,
                 "height": 92,
-                "left": 1294,
-                "right": 1494,
-                "top": 658.5,
+                "left": -2721.5,
+                "right": -2521.5,
+                "top": 613,
                 "width": 200,
-                "x": 1294,
-                "y": 658.5
+                "x": -2721.5,
+                "y": 613
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionout_file1": {
@@ -821,7 +782,7 @@
                 }
             },
             "tool_id": "Cut1",
-            "tool_state": "{\"columnList\": \"c1,c4\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"columnList\": \"c1,c4\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "4e1efb96-8d39-4e89-8a77-a2a6d5ec7578",
@@ -829,7 +790,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "d6cfb911-54be-4ecc-a6ac-64b5a862d4b5"
+                    "uuid": "736a8001-fa58-465f-b31a-5ec9ed96c458"
                 }
             ]
         },
@@ -840,15 +801,15 @@
             "id": 16,
             "input_connections": {
                 "barcodes": {
-                    "id": 4,
+                    "id": 6,
                     "output_name": "output"
                 },
                 "cell_meta": {
-                    "id": 3,
+                    "id": 5,
                     "output_name": "output"
                 },
                 "gene_meta": {
-                    "id": 10,
+                    "id": 11,
                     "output_name": "feature_annotation"
                 },
                 "genes": {
@@ -856,32 +817,11 @@
                     "output_name": "out_file1"
                 },
                 "matrix": {
-                    "id": 2,
+                    "id": 4,
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x",
-                    "name": "barcodes"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x",
-                    "name": "cell_meta"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x",
-                    "name": "gene_meta"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x",
-                    "name": "genes"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy Read10x",
-                    "name": "matrix"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Scanpy Read10x",
             "outputs": [
@@ -891,14 +831,14 @@
                 }
             ],
             "position": {
-                "bottom": 651.5,
+                "bottom": 606,
                 "height": 292,
-                "left": 1582,
-                "right": 1782,
-                "top": 359.5,
+                "left": -2433.5,
+                "right": -2233.5,
+                "top": 314,
                 "width": 200,
-                "x": 1582,
-                "y": 359.5
+                "x": -2433.5,
+                "y": 314
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -919,7 +859,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"barcodes\": {\"__class__\": \"RuntimeValue\"}, \"cell_meta\": {\"__class__\": \"RuntimeValue\"}, \"gene_meta\": {\"__class__\": \"RuntimeValue\"}, \"genes\": {\"__class__\": \"RuntimeValue\"}, \"matrix\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"var_names\": \"gene_ids\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"barcodes\": {\"__class__\": \"ConnectedValue\"}, \"cell_meta\": {\"__class__\": \"ConnectedValue\"}, \"gene_meta\": {\"__class__\": \"ConnectedValue\"}, \"genes\": {\"__class__\": \"ConnectedValue\"}, \"matrix\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"var_names\": \"gene_ids\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
             "uuid": "1af61f15-d508-41d7-9123-b08b66458ad8",
@@ -936,12 +876,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FilterCells",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "filter_cells",
             "name": "Scanpy FilterCells",
             "outputs": [
@@ -963,14 +898,14 @@
                 }
             ],
             "position": {
-                "bottom": 740.5,
+                "bottom": 695,
                 "height": 362,
-                "left": 1860,
-                "right": 2060,
-                "top": 378.5,
+                "left": -2155.5,
+                "right": -1955.5,
+                "top": 333,
                 "width": 200,
-                "x": 1860,
-                "y": 378.5
+                "x": -2155.5,
+                "y": 333
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1006,7 +941,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"gene_name\": \"gene_symbols\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_genes\", \"min\": \"400.0\", \"max\": \"1000000000.0\"}, {\"__index__\": 1, \"name\": \"n_counts\", \"min\": \"0.0\", \"max\": \"1000000000.0\"}], \"subsets\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"gene_name\": \"gene_symbols\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_genes\", \"min\": \"400.0\", \"max\": \"1000000000.0\"}, {\"__index__\": 1, \"name\": \"n_counts\", \"min\": \"0.0\", \"max\": \"1000000000.0\"}], \"subsets\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
             "uuid": "3d899480-ea8f-4450-baa1-518b1f1c222a",
@@ -1023,16 +958,11 @@
                     "output_name": "output_h5ad"
                 },
                 "subsets_0|subset": {
-                    "id": 11,
+                    "id": 10,
                     "output_name": "feature_annotation"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FilterGenes",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "filter_genes",
             "name": "Scanpy FilterGenes",
             "outputs": [
@@ -1054,14 +984,14 @@
                 }
             ],
             "position": {
-                "bottom": 621.5,
+                "bottom": 576,
                 "height": 432,
-                "left": 2138,
-                "right": 2338,
-                "top": 189.5,
+                "left": -1877.5,
+                "right": -1677.5,
+                "top": 144,
                 "width": 200,
-                "x": 2138,
-                "y": 189.5
+                "x": -1877.5,
+                "y": 144
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1103,25 +1033,25 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_cells\", \"min\": \"3.0\", \"max\": \"1000000000.0\"}], \"subsets\": [{\"__index__\": 0, \"name\": \"index\", \"subset\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_cells\", \"min\": \"3.0\", \"max\": \"1000000000.0\"}], \"subsets\": [{\"__index__\": 0, \"name\": \"index\", \"subset\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
             "uuid": "1c7ea27f-d533-4315-8ee1-49d0de3e66de",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "genes_10x",
-                    "uuid": "cb555fd4-046e-4b90-839f-164de0e58dfd"
+                    "output_name": "barcodes_10x",
+                    "uuid": "1a243b62-5f52-4eb3-84e5-2cec59d1c830"
                 },
                 {
                     "label": null,
-                    "output_name": "barcodes_10x",
-                    "uuid": "2de1b144-155b-461e-be0b-6deb34ac1d21"
+                    "output_name": "genes_10x",
+                    "uuid": "b298d383-edb8-44a8-b3d3-b5ad7bac80ef"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "e9655a0d-e7c8-4456-9046-ef65e13744bc"
+                    "uuid": "4caca98b-a231-4fb9-9af3-fb1a016e19d0"
                 }
             ]
         },
@@ -1136,12 +1066,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy NormaliseData",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "normalise_data_internal",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1151,14 +1076,14 @@
                 }
             ],
             "position": {
-                "bottom": 309.5,
+                "bottom": 264,
                 "height": 192,
-                "left": 2416,
-                "right": 2616,
-                "top": 117.5,
+                "left": -1599.5,
+                "right": -1399.5,
+                "top": 72,
                 "width": 200,
-                "x": 2416,
-                "y": 117.5
+                "x": -1599.5,
+                "y": 72
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1179,7 +1104,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
             "uuid": "6c7c53cb-ac61-4c51-b09e-7491256e078a",
@@ -1196,12 +1121,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy NormaliseData",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "normalise_data",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1223,14 +1143,14 @@
                 }
             ],
             "position": {
-                "bottom": 729.5,
+                "bottom": 684,
                 "height": 382,
-                "left": 2416,
-                "right": 2616,
-                "top": 347.5,
+                "left": -1599.5,
+                "right": -1399.5,
+                "top": 302,
                 "width": 200,
-                "x": 2416,
-                "y": 347.5
+                "x": -1599.5,
+                "y": 302
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1272,25 +1192,25 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
             "uuid": "51574e14-2149-4112-8185-75385c4af358",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "barcodes_10x",
-                    "uuid": "abf47064-5e0f-4bd6-8f78-ee92d8315949"
+                    "output_name": "genes_10x",
+                    "uuid": "3f01b233-eefc-4f0c-ba41-e185a8477b10"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "958aec69-223c-4ddf-b861-b894756c2837"
+                    "uuid": "ab42412b-94bd-4042-b775-d7ceb2f1b441"
                 },
                 {
                     "label": null,
-                    "output_name": "genes_10x",
-                    "uuid": "0e347d03-6fe9-4f93-857a-d1ee7c2900ba"
+                    "output_name": "barcodes_10x",
+                    "uuid": "ac7b9d01-f680-43a1-a9df-593698e947ed"
                 }
             ]
         },
@@ -1305,12 +1225,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindVariableGenes",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "find_variable_genes",
             "name": "Scanpy FindVariableGenes",
             "outputs": [
@@ -1320,14 +1235,14 @@
                 }
             ],
             "position": {
-                "bottom": 309.5,
+                "bottom": 264,
                 "height": 192,
-                "left": 2694,
-                "right": 2894,
-                "top": 117.5,
+                "left": -1321.5,
+                "right": -1121.5,
+                "top": 72,
                 "width": 200,
-                "x": 2694,
-                "y": 117.5
+                "x": -1321.5,
+                "y": 72
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1348,7 +1263,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"batch_key\": \"\", \"filter\": \"false\", \"flavor\": \"seurat\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"max_disp\": \"50.0\", \"max_mean\": \"1000000000.0\", \"min_disp\": \"0.5\", \"min_mean\": \"0.0125\", \"n_bin\": \"20\", \"n_top_gene\": \"\", \"output_format\": \"anndata_h5ad\", \"span\": \"0.3\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"batch_key\": \"\", \"filter\": \"false\", \"flavor\": \"seurat\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"max_disp\": \"50.0\", \"max_mean\": \"1000000000.0\", \"min_disp\": \"0.5\", \"min_mean\": \"0.0125\", \"n_bin\": \"20\", \"n_top_gene\": \"\", \"output_format\": \"anndata_h5ad\", \"span\": \"0.3\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
             "uuid": "e34f75bb-b3b3-4177-983e-dae86d835f01",
@@ -1365,12 +1280,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunPCA",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "run_pca",
             "name": "Scanpy RunPCA",
             "outputs": [
@@ -1380,14 +1290,14 @@
                 }
             ],
             "position": {
-                "bottom": 289.5,
+                "bottom": 244,
                 "height": 152,
-                "left": 2972,
-                "right": 3172,
-                "top": 137.5,
+                "left": -1043.5,
+                "right": -843.5,
+                "top": 92,
                 "width": 200,
-                "x": 2972,
-                "y": 137.5
+                "x": -1043.5,
+                "y": 92
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1408,7 +1318,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"extra_outputs\": null, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"n_pcs\": \"\", \"output_format\": \"anndata_h5ad\", \"run_mode\": {\"chunked\": \"false\", \"__current_case__\": 1, \"zero_center\": \"false\", \"svd_solver\": \"arpack\", \"random_seed\": \"1234\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"extra_outputs\": null, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"n_pcs\": \"\", \"output_format\": \"anndata_h5ad\", \"run_mode\": {\"chunked\": \"false\", \"__current_case__\": 1, \"zero_center\": \"false\", \"svd_solver\": \"arpack\", \"random_seed\": \"1234\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
             "uuid": "96cc02ec-f20b-4ec1-8642-2d3c9df3f274",
@@ -1425,12 +1335,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy Harmony",
-                    "name": "input_obj_file"
-                }
-            ],
+            "inputs": [],
             "label": "harmony_batch",
             "name": "Scanpy Harmony",
             "outputs": [
@@ -1440,14 +1345,14 @@
                 }
             ],
             "position": {
-                "bottom": 309.5,
+                "bottom": 264,
                 "height": 192,
-                "left": 3250,
-                "right": 3450,
-                "top": 117.5,
+                "left": -765.5,
+                "right": -565.5,
+                "top": 72,
                 "width": 200,
-                "x": 3250,
-                "y": 117.5
+                "x": -765.5,
+                "y": 72
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1468,7 +1373,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adjusted_basis\": \"X_pca\", \"basis\": \"X_pca\", \"batch_key\": \"BATCH_FIELD\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"true\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adjusted_basis\": \"X_pca\", \"basis\": \"X_pca\", \"batch_key\": \"BATCH_FIELD\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"true\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
             "uuid": "ff1608fa-d723-4578-87d1-b6bba0c3aece",
@@ -1485,20 +1390,11 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|perplexity_file": {
-                    "id": 5,
+                    "id": 2,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy RunTSNE",
-                    "name": "input_obj_file"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy RunTSNE",
-                    "name": "settings"
-                }
-            ],
+            "inputs": [],
             "label": "run_tsne",
             "name": "Scanpy RunTSNE",
             "outputs": [
@@ -1512,14 +1408,14 @@
                 }
             ],
             "position": {
-                "bottom": 409.5,
+                "bottom": 364,
                 "height": 292,
-                "left": 3538,
-                "right": 3738,
-                "top": 117.5,
+                "left": -477.5,
+                "right": -277.5,
+                "top": 72,
                 "width": 200,
-                "x": 3538,
-                "y": 117.5
+                "x": -477.5,
+                "y": 72
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1554,7 +1450,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"perplexity_PERPLEXITY\", \"perplexity\": \"30.0\", \"perplexity_file\": {\"__class__\": \"RuntimeValue\"}, \"early_exaggeration\": \"12.0\", \"learning_rate\": \"400.0\", \"fast_tsne\": \"false\", \"n_job\": \"\", \"n_pc\": \"\", \"random_seed\": \"1234\"}, \"use_rep\": \"auto\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"perplexity_PERPLEXITY\", \"perplexity\": \"30.0\", \"perplexity_file\": {\"__class__\": \"ConnectedValue\"}, \"early_exaggeration\": \"12.0\", \"learning_rate\": \"400.0\", \"fast_tsne\": \"false\", \"n_job\": \"\", \"n_pc\": \"\", \"random_seed\": \"1234\"}, \"use_rep\": \"auto\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy2",
             "type": "tool",
             "uuid": "5a8ce1c2-d259-4b85-b34b-9bde3fa1af6d",
@@ -1562,7 +1458,7 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "e89bf8bf-e3c3-45aa-8c4b-5d129ab5baba"
+                    "uuid": "e18d5ec3-4bba-4b46-bc7f-ee26200d629b"
                 }
             ]
         },
@@ -1580,10 +1476,6 @@
             "inputs": [
                 {
                     "description": "runtime parameter for tool Scanpy ComputeGraph",
-                    "name": "input_obj_file"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph",
                     "name": "settings"
                 }
             ],
@@ -1596,14 +1488,14 @@
                 }
             ],
             "position": {
-                "bottom": -104.5,
+                "bottom": -150,
                 "height": 242,
-                "left": 3538,
-                "right": 3738,
-                "top": -346.5,
+                "left": -477.5,
+                "right": -277.5,
+                "top": -392,
                 "width": 200,
-                "x": 3538,
-                "y": -346.5
+                "x": -477.5,
+                "y": -392
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1624,7 +1516,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
             "uuid": "a3b89f7b-c3b4-42fc-9943-22d2939518df",
@@ -1641,20 +1533,11 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|n_neighbors_file": {
-                    "id": 6,
+                    "id": 3,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph",
-                    "name": "input_obj_file"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph",
-                    "name": "settings"
-                }
-            ],
+            "inputs": [],
             "label": "neighbours for umap",
             "name": "Scanpy ComputeGraph",
             "outputs": [
@@ -1664,14 +1547,14 @@
                 }
             ],
             "position": {
-                "bottom": 709.5,
+                "bottom": 664,
                 "height": 262,
-                "left": 3538,
-                "right": 3738,
-                "top": 447.5,
+                "left": -477.5,
+                "right": -277.5,
+                "top": 402,
                 "width": 200,
-                "x": 3538,
-                "y": 447.5
+                "x": -477.5,
+                "y": 402
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1699,7 +1582,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"ConnectedValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
             "uuid": "9dd6efe7-ab3e-4027-9b73-55025387f9b0",
@@ -1716,12 +1599,7 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Filter failed",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Filter failed",
             "outputs": [
@@ -1731,14 +1609,14 @@
                 }
             ],
             "position": {
-                "bottom": 524.5,
+                "bottom": 479,
                 "height": 112,
-                "left": 4104,
-                "right": 4304,
-                "top": 412.5,
+                "left": 88.5,
+                "right": 288.5,
+                "top": 367,
                 "width": 200,
-                "x": 4104,
-                "y": 412.5
+                "x": 88.5,
+                "y": 367
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1748,7 +1626,7 @@
                 }
             },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "92c08e50-114f-4a3a-95b9-4a4ec20fff5d",
@@ -1756,7 +1634,7 @@
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "cbe1e012-9180-4a56-b9ed-648c85d7c980"
+                    "uuid": "2b4d8037-7b4e-400e-93ce-eb612c78c70e"
                 }
             ]
         },
@@ -1771,20 +1649,11 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|resolution_file": {
-                    "id": 7,
+                    "id": 1,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy FindCluster",
-                    "name": "input_obj_file"
-                },
-                {
-                    "description": "runtime parameter for tool Scanpy FindCluster",
-                    "name": "settings"
-                }
-            ],
+            "inputs": [],
             "label": "find_clusters",
             "name": "Scanpy FindCluster",
             "outputs": [
@@ -1798,14 +1667,14 @@
                 }
             ],
             "position": {
-                "bottom": 180.5,
+                "bottom": 135,
                 "height": 312,
-                "left": 3826,
-                "right": 4026,
-                "top": -131.5,
+                "left": -189.5,
+                "right": 10.5,
+                "top": -177,
                 "width": 200,
-                "x": 3826,
-                "y": -131.5
+                "x": -189.5,
+                "y": -177
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5ad": {
@@ -1840,7 +1709,7 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"method\": \"louvain\", \"output_cluster\": \"true\", \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"neighbors_key\": \"neighbors\", \"layer\": \"\", \"key_added\": \"METHOD_resolution_RESOLUTION\", \"resolution\": \"1.0\", \"resolution_file\": {\"__class__\": \"RuntimeValue\"}, \"restrict_to\": \"\", \"use_weights\": \"false\", \"random_seed\": \"1234\", \"directed\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"louvain\", \"output_cluster\": \"true\", \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"neighbors_key\": \"neighbors\", \"layer\": \"\", \"key_added\": \"METHOD_resolution_RESOLUTION\", \"resolution\": \"1.0\", \"resolution_file\": {\"__class__\": \"ConnectedValue\"}, \"restrict_to\": \"\", \"use_weights\": \"false\", \"random_seed\": \"1234\", \"directed\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
             "uuid": "3bdeb84a-d8ee-4319-a99f-2f2fa6e0d275",
@@ -1848,7 +1717,7 @@
                 {
                     "label": null,
                     "output_name": "output_txt",
-                    "uuid": "4169db18-ac84-4913-8c3f-47b7c8a17bf2"
+                    "uuid": "57a16418-ca50-44c5-a2af-5fab94e051db"
                 }
             ]
         },
@@ -1873,14 +1742,14 @@
                 }
             ],
             "position": {
-                "bottom": -169.5,
+                "bottom": -215,
                 "height": 112,
-                "left": 3826,
-                "right": 4026,
-                "top": -281.5,
+                "left": -189.5,
+                "right": 10.5,
+                "top": -327,
                 "width": 200,
-                "x": 3826,
-                "y": -281.5
+                "x": -189.5,
+                "y": -327
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1895,7 +1764,7 @@
                 }
             },
             "tool_id": "__BUILD_LIST__",
-            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "4342456b-ed0a-45e1-b9d7-1cb1effd0cab",
@@ -1926,14 +1795,14 @@
                 }
             ],
             "position": {
-                "bottom": 729.5,
+                "bottom": 684,
                 "height": 222,
-                "left": 3826,
-                "right": 4026,
-                "top": 507.5,
+                "left": -189.5,
+                "right": 10.5,
+                "top": 462,
                 "width": 200,
-                "x": 3826,
-                "y": 507.5
+                "x": -189.5,
+                "y": 462
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1969,7 +1838,7 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "330ddaaa-f0f0-40b2-b732-2834ff9f04a4"
+                    "uuid": "50aca7ff-cf3e-4653-806c-300b29518988"
                 }
             ]
         },
@@ -1998,21 +1867,16 @@
                 }
             ],
             "position": {
-                "bottom": 88.5,
+                "bottom": 43,
                 "height": 202,
-                "left": 4104,
-                "right": 4304,
-                "top": -113.5,
+                "left": 88.5,
+                "right": 288.5,
+                "top": -159,
                 "width": 200,
-                "x": 4104,
-                "y": -113.5
+                "x": 88.5,
+                "y": -159
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output"
-                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -2023,7 +1887,7 @@
             "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "fad780b1-7920-46c4-9fbf-a1e16500b9ca",
+            "uuid": "201f139a-b35a-4835-94ab-045da797611a",
             "workflow_outputs": []
         },
         "32": {
@@ -2037,12 +1901,7 @@
                     "output_name": "output_h5"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Filter failed",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Filter failed",
             "outputs": [
@@ -2052,14 +1911,14 @@
                 }
             ],
             "position": {
-                "bottom": 674.5,
+                "bottom": 629,
                 "height": 112,
-                "left": 4104,
-                "right": 4304,
-                "top": 562.5,
+                "left": 88.5,
+                "right": 288.5,
+                "top": 517,
                 "width": 200,
-                "x": 4104,
-                "y": 562.5
+                "x": 88.5,
+                "y": 517
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2069,7 +1928,7 @@
                 }
             },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "84eeb9b8-79f5-477f-b252-8004ceed8f6f",
@@ -2077,7 +1936,7 @@
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "762bf5e8-433a-4ffe-b6a5-c29305d6c61d"
+                    "uuid": "1c9b956c-9ea2-4ee4-9be5-863c5b5844bb"
                 }
             ]
         },
@@ -2088,7 +1947,7 @@
             "id": 33,
             "input_connections": {
                 "groupby_file": {
-                    "id": 14,
+                    "id": 13,
                     "output_name": "output"
                 },
                 "input_obj_file": {
@@ -2119,21 +1978,16 @@
                 }
             ],
             "position": {
-                "bottom": 419.5,
+                "bottom": 374,
                 "height": 292,
-                "left": 4382,
-                "right": 4582,
-                "top": 127.5,
+                "left": 366.5,
+                "right": 566.5,
+                "top": 82,
                 "width": 200,
-                "x": 4382,
-                "y": 127.5
+                "x": 366.5,
+                "y": 82
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5ad": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5ad"
-                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -2157,12 +2011,12 @@
             "tool_state": "{\"groupby\": \"INPUT_OBJ\", \"groupby_file\": {\"__class__\": \"RuntimeValue\"}, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"n_genes\": \"100\", \"output_format\": \"anndata_h5ad\", \"output_markers\": \"true\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"markers_GROUPBY\", \"method\": \"t-test_overestim_var\", \"use_raw\": \"true\", \"rankby_abs\": \"false\", \"groups\": \"\", \"reference\": \"rest\", \"min_in_group_fraction\": \"0.0\", \"max_out_group_fraction\": \"1.0\", \"min_fold_change\": \"1.0\", \"pts\": \"false\", \"tie_correct\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy4",
             "type": "tool",
-            "uuid": "5039cb89-8bb3-4f88-8d7d-0ce9c081aa3b",
+            "uuid": "f78fc439-088c-4411-ac8f-41c69c721e7b",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_tsv",
-                    "uuid": "409c1ba5-cbcd-4492-99b1-45214f23cafd"
+                    "uuid": "d098c457-6ec6-4387-8dca-ebb81f3637aa"
                 }
             ]
         },
@@ -2191,21 +2045,16 @@
                 }
             ],
             "position": {
-                "bottom": 682.5,
+                "bottom": 637,
                 "height": 202,
-                "left": 4382,
-                "right": 4582,
-                "top": 480.5,
+                "left": 366.5,
+                "right": 566.5,
+                "top": 435,
                 "width": 200,
-                "x": 4382,
-                "y": 480.5
+                "x": 366.5,
+                "y": 435
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output"
-                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -2213,10 +2062,10 @@
                 }
             },
             "tool_id": "__MERGE_COLLECTION__",
-            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "02f93344-d954-4a14-a8de-5482ea7adbd0",
+            "uuid": "a6481256-820e-4a8e-aa5d-55fdb1b1fdd5",
             "workflow_outputs": []
         },
         "35": {
@@ -2230,7 +2079,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter failed",
+                    "name": "input"
+                }
+            ],
             "label": "Filtered cellgroup markers",
             "name": "Filter failed",
             "outputs": [
@@ -2240,21 +2094,16 @@
                 }
             ],
             "position": {
-                "bottom": 517.5,
+                "bottom": 472,
                 "height": 132,
-                "left": 4660,
-                "right": 4860,
-                "top": 385.5,
+                "left": 644.5,
+                "right": 844.5,
+                "top": 340,
                 "width": 200,
-                "x": 4660,
-                "y": 385.5
+                "x": 644.5,
+                "y": 340
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output"
-                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -2262,10 +2111,10 @@
                 }
             },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "ed346e6d-aadb-4dbf-a23a-86a1714aea5f",
+            "uuid": "b6bbbc4f-c0c1-4ade-b608-1059a4a8bfa1",
             "workflow_outputs": []
         },
         "36": {
@@ -2309,14 +2158,14 @@
                 }
             ],
             "position": {
-                "bottom": 832.5,
+                "bottom": 787,
                 "height": 502,
-                "left": 4948,
-                "right": 5148,
-                "top": 330.5,
+                "left": 932.5,
+                "right": 1132.5,
+                "top": 285,
                 "width": 200,
-                "x": 4948,
-                "y": 330.5
+                "x": 932.5,
+                "y": 285
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -2342,12 +2191,12 @@
                 {
                     "label": null,
                     "output_name": "output_h5ad",
-                    "uuid": "fc75c7b8-aa79-4fd6-91a8-db6ade94ad71"
+                    "uuid": "e66e4255-b377-4bad-807c-16f2a740dbdd"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "48e6f224-f778-47ad-8e6c-e723570aa3c7",
-    "version": 16
+    "uuid": "697addd9-d0e4-4520-8c01-223e303445ed",
+    "version": 17
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -2,58 +2,165 @@
     "a_galaxy_workflow": "true",
     "annotation": "",
     "format-version": "0.1",
-    "name": "Scanpy Prod 1.6.0 clustering with Harmony batch adjustment (h5ad) - groupby as file (v0.2.2)",
+    "name": "Scanpy Prod 1.6.0 clustering with Harmony batch adjustment (h5ad) - improved matrix handling (v0.2.3)",
     "steps": {
         "0": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "content_id": null,
             "errors": null,
             "id": 0,
             "input_connections": {},
-            "inputs": [],
-            "label": "n_neighbors",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
+            "inputs": [
                 {
-                    "name": "parameter_iteration",
-                    "type": "input"
+                    "description": "",
+                    "name": "barcodes"
                 }
             ],
+            "label": "barcodes",
+            "name": "Input dataset",
+            "outputs": [],
             "position": {
-                "bottom": 172,
-                "height": 81,
-                "left": -333.5,
-                "right": -133.5,
-                "top": 91,
+                "bottom": 96.5,
+                "height": 61,
+                "left": -729.5,
+                "right": -529.5,
+                "top": 35.5,
                 "width": 200,
-                "x": -333.5,
-                "y": 91
+                "x": -729.5,
+                "y": 35.5
             },
-            "post_job_actions": {
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "362edaae-5b4f-4f97-b03c-f29aa6a63878"
                 }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "fb354a78d4ae",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy2",
-            "type": "tool",
-            "uuid": "a9e2b9c4-7b48-4014-9006-e8c48faa41c5",
-            "workflow_outputs": []
+            ]
         },
         "1": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "content_id": null,
             "errors": null,
             "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "cellmeta"
+                }
+            ],
+            "label": "cellmeta",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 195.5,
+                "height": 61,
+                "left": -729.5,
+                "right": -529.5,
+                "top": 134.5,
+                "width": 200,
+                "x": -729.5,
+                "y": 134.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "1bf13ed9-e246-492a-9b04-cbcff7427aaf"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "matrix"
+                }
+            ],
+            "label": "matrix",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 294.5,
+                "height": 61,
+                "left": -729.5,
+                "right": -529.5,
+                "top": 233.5,
+                "width": 200,
+                "x": -729.5,
+                "y": 233.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "2e1dd437-7f9b-4688-ad37-920c9ff8c668"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "genes"
+                }
+            ],
+            "label": "genes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 89.5,
+                "height": 61,
+                "left": -1285.5,
+                "right": -1085.5,
+                "top": 28.5,
+                "width": 200,
+                "x": -1285.5,
+                "y": 28.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "79451756-8ed4-4600-a94b-3603b3b6d147",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "a2a81673-2ce1-4280-a365-792476011657"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "errors": null,
+            "id": 4,
             "input_connections": {},
             "inputs": [],
             "label": "perplexity",
@@ -65,14 +172,14 @@
                 }
             ],
             "position": {
-                "bottom": 457,
+                "bottom": 773.5,
                 "height": 81,
-                "left": -333.5,
-                "right": -133.5,
-                "top": 376,
+                "left": 1216.5,
+                "right": 1416.5,
+                "top": 692.5,
                 "width": 200,
-                "x": -333.5,
-                "y": 376
+                "x": 1216.5,
+                "y": 692.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -96,59 +203,14 @@
             "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50\"}, \"parameter_name\": \"perplexity\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.1+galaxy1",
             "type": "tool",
-            "uuid": "b2b878e0-3f41-45cd-8472-c7a59c334568",
+            "uuid": "00700721-8faf-4f86-9d80-2daf4bebffeb",
             "workflow_outputs": []
         },
-        "2": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
-            "errors": null,
-            "id": 2,
-            "input_connections": {},
-            "inputs": [],
-            "label": "meta_vars",
-            "name": "Scanpy ParameterIterator",
-            "outputs": [
-                {
-                    "name": "parameter_iteration",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 1346,
-                "height": 81,
-                "left": 222.5,
-                "right": 422.5,
-                "top": 1265,
-                "width": 200,
-                "x": 222.5,
-                "y": 1265
-            },
-            "post_job_actions": {
-                "HideDatasetActionparameter_iteration": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "parameter_iteration"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "b9dd12ab0550",
-                "name": "scanpy_parameter_iterator",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"CELL_TYPE_FIELD\"}, \"parameter_name\": \"meta\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.1+galaxy3",
-            "type": "tool",
-            "uuid": "ac7e7888-f93f-495f-8563-ade504429071",
-            "workflow_outputs": []
-        },
-        "3": {
+        "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
             "errors": null,
-            "id": 3,
+            "id": 5,
             "input_connections": {},
             "inputs": [],
             "label": "resolution",
@@ -160,14 +222,14 @@
                 }
             ],
             "position": {
-                "bottom": 1480,
+                "bottom": 549.5,
                 "height": 81,
-                "left": -55.5,
-                "right": 144.5,
-                "top": 1399,
+                "left": 1494.5,
+                "right": 1694.5,
+                "top": 468.5,
                 "width": 200,
-                "x": -55.5,
-                "y": 1399
+                "x": 1494.5,
+                "y": 468.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -191,166 +253,14 @@
             "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 3.0, 4.0, 5.0\"}, \"parameter_name\": \"resolution\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.1+galaxy1",
             "type": "tool",
-            "uuid": "d1228db0-6989-4ff0-92ba-1116b65cb6fb",
+            "uuid": "4b596e78-fbaa-423a-9a66-f696600ad75b",
             "workflow_outputs": []
-        },
-        "4": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 4,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "barcodes"
-                }
-            ],
-            "label": "barcodes",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 169,
-                "height": 61,
-                "left": -2289.5,
-                "right": -2089.5,
-                "top": 108,
-                "width": 200,
-                "x": -2289.5,
-                "y": 108
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "810b3d00-69d4-4097-a6ab-258a30261f60",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "f276a4e1-d2b6-497f-b6ab-71160146cceb"
-                }
-            ]
-        },
-        "5": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 5,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "cellmeta"
-                }
-            ],
-            "label": "cellmeta",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 268,
-                "height": 61,
-                "left": -2289.5,
-                "right": -2089.5,
-                "top": 207,
-                "width": 200,
-                "x": -2289.5,
-                "y": 207
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "386ad6f2-edc5-4a32-b378-488285b7e8e5",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "97481deb-132a-49cd-91b0-dadf9a9b5ca5"
-                }
-            ]
         },
         "6": {
             "annotation": "",
             "content_id": null,
             "errors": null,
             "id": 6,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "matrix"
-                }
-            ],
-            "label": "matrix",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 367,
-                "height": 61,
-                "left": -2289.5,
-                "right": -2089.5,
-                "top": 306,
-                "width": 200,
-                "x": -2289.5,
-                "y": 306
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "5908f4f6-4bb5-46ef-876c-86d9ebb899cc",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "4a58b174-08a7-4484-8b70-f4dd5b402a03"
-                }
-            ]
-        },
-        "7": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 7,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "genes"
-                }
-            ],
-            "label": "genes",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 327,
-                "height": 61,
-                "left": -2845.5,
-                "right": -2645.5,
-                "top": 266,
-                "width": 200,
-                "x": -2845.5,
-                "y": 266
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "b1b82031-8d1c-4253-a25d-c11a10087c64",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "fe09db2a-403c-4faf-a697-f7145507046e"
-                }
-            ]
-        },
-        "8": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 8,
             "input_connections": {},
             "inputs": [
                 {
@@ -362,27 +272,117 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 461,
+                "bottom": 343.5,
                 "height": 61,
-                "left": -3123.5,
-                "right": -2923.5,
-                "top": 400,
+                "left": -1563.5,
+                "right": -1363.5,
+                "top": 282.5,
                 "width": 200,
-                "x": -3123.5,
-                "y": 400
+                "x": -1563.5,
+                "y": 282.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "96a164a1-8f5f-4572-8874-7095c2ee076b",
+            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "6e9afd9f-e482-4026-8a02-f369f821055d"
+                    "uuid": "9309b751-9459-4d25-9897-f7fb10dbe3ff"
                 }
             ]
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "errors": null,
+            "id": 7,
+            "input_connections": {},
+            "inputs": [],
+            "label": "n_neighbors",
+            "name": "Scanpy ParameterIterator",
+            "outputs": [
+                {
+                    "name": "parameter_iteration",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 1135.5,
+                "height": 81,
+                "left": 1216.5,
+                "right": 1416.5,
+                "top": 1054.5,
+                "width": 200,
+                "x": 1216.5,
+                "y": 1054.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "fb354a78d4ae",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy2",
+            "type": "tool",
+            "uuid": "5e22d4cd-71d6-4a91-b326-508494138b82",
+            "workflow_outputs": []
+        },
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
+            "errors": null,
+            "id": 8,
+            "input_connections": {},
+            "inputs": [],
+            "label": "meta_vars",
+            "name": "Scanpy ParameterIterator",
+            "outputs": [
+                {
+                    "name": "parameter_iteration",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 749.5,
+                "height": 81,
+                "left": 1782.5,
+                "right": 1982.5,
+                "top": 668.5,
+                "width": 200,
+                "x": 1782.5,
+                "y": 668.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parameter_iteration"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "b9dd12ab0550",
+                "name": "scanpy_parameter_iterator",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"CELL_TYPE_FIELD\"}, \"parameter_name\": \"meta\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.1+galaxy3",
+            "type": "tool",
+            "uuid": "7942bdd0-8738-42ff-9251-10886d5125a6",
+            "workflow_outputs": []
         },
         "9": {
             "annotation": "",
@@ -391,7 +391,7 @@
             "id": 9,
             "input_connections": {
                 "infile": {
-                    "id": 3,
+                    "id": 5,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -405,14 +405,14 @@
                 }
             ],
             "position": {
-                "bottom": 1496,
+                "bottom": 899.5,
                 "height": 112,
-                "left": 222.5,
-                "right": 422.5,
-                "top": 1384,
+                "left": 1782.5,
+                "right": 1982.5,
+                "top": 787.5,
                 "width": 200,
-                "x": 222.5,
-                "y": 1384
+                "x": 1782.5,
+                "y": 787.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -438,7 +438,7 @@
             "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
-            "uuid": "fab045e5-d7bf-41eb-bbdf-76d5bc6c3a48",
+            "uuid": "2c325236-8140-4904-9a72-5a037f7484b8",
             "workflow_outputs": []
         },
         "10": {
@@ -448,7 +448,7 @@
             "id": 10,
             "input_connections": {
                 "gtf_input": {
-                    "id": 8,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -462,71 +462,14 @@
                 }
             ],
             "position": {
-                "bottom": 582,
+                "bottom": 379.5,
                 "height": 132,
-                "left": -2001.5,
-                "right": -1801.5,
-                "top": 450,
+                "left": -1007.5,
+                "right": -807.5,
+                "top": 247.5,
                 "width": 200,
-                "x": -2001.5,
-                "y": 450
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionfeature_annotation": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "feature_annotation"
-                },
-                "HideDatasetActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "feature_annotation"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9",
-                "name": "gtf2gene_list",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.42.1+galaxy4",
-            "type": "tool",
-            "uuid": "12da8d58-6fa8-4c5e-b0a5-aa2230a37b19",
-            "workflow_outputs": []
-        },
-        "11": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "errors": null,
-            "id": 11,
-            "input_connections": {
-                "gtf_input": {
-                    "id": 8,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "GTF2GeneList",
-            "outputs": [
-                {
-                    "name": "feature_annotation",
-                    "type": "tsv"
-                }
-            ],
-            "position": {
-                "bottom": 295,
-                "height": 132,
-                "left": -2567.5,
-                "right": -2367.5,
-                "top": 163,
-                "width": 200,
-                "x": -2567.5,
-                "y": 163
+                "x": -1007.5,
+                "y": 247.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -552,17 +495,17 @@
             "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "807d0865-881f-4491-b48a-01249910afcc",
+            "uuid": "5c0d8c50-7891-4dc6-826f-0e5a6d3117bb",
             "workflow_outputs": []
         },
-        "12": {
+        "11": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
-            "id": 12,
+            "id": 11,
             "input_connections": {
                 "gtf_input": {
-                    "id": 8,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -576,14 +519,71 @@
                 }
             ],
             "position": {
-                "bottom": 497,
+                "bottom": 549.5,
                 "height": 132,
-                "left": -2845.5,
-                "right": -2645.5,
-                "top": 365,
+                "left": -1007.5,
+                "right": -807.5,
+                "top": 417.5,
                 "width": 200,
-                "x": -2845.5,
-                "y": 365
+                "x": -1007.5,
+                "y": 417.5
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "feature_annotation"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9",
+                "name": "gtf2gene_list",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.42.1+galaxy4",
+            "type": "tool",
+            "uuid": "a341aa66-f857-49b2-9614-a7231237d5ce",
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "gtf_input": {
+                    "id": 6,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "GTF2GeneList",
+            "outputs": [
+                {
+                    "name": "feature_annotation",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "bottom": -9.5,
+                "height": 132,
+                "left": -1285.5,
+                "right": -1085.5,
+                "top": -141.5,
+                "width": 200,
+                "x": -1285.5,
+                "y": -141.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -609,7 +609,7 @@
             "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id,gene_name\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "2bfeaaf7-929d-44cd-9a6b-3d2dea443211",
+            "uuid": "d14f7483-6bbb-4262-a1b1-2d8bb09457d7",
             "workflow_outputs": []
         },
         "13": {
@@ -623,7 +623,7 @@
                     "output_name": "outfile"
                 },
                 "inputs_1|input": {
-                    "id": 2,
+                    "id": 8,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -637,14 +637,14 @@
                 }
             ],
             "position": {
-                "bottom": 1444,
+                "bottom": 824.5,
                 "height": 202,
-                "left": 500.5,
-                "right": 700.5,
-                "top": 1242,
+                "left": 2060.5,
+                "right": 2260.5,
+                "top": 622.5,
                 "width": 200,
-                "x": 500.5,
-                "y": 1242
+                "x": 2060.5,
+                "y": 622.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -657,7 +657,7 @@
             "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "3d8514e4-0a25-41c5-8f09-fbfaf91a52e6",
+            "uuid": "ba78a440-74fd-4fe1-972e-69004ee2186f",
             "workflow_outputs": []
         },
         "14": {
@@ -667,7 +667,7 @@
             "id": 14,
             "input_connections": {
                 "input1": {
-                    "id": 7,
+                    "id": 3,
                     "output_name": "output"
                 },
                 "input2": {
@@ -685,26 +685,26 @@
                 }
             ],
             "position": {
-                "bottom": 475,
+                "bottom": 22.5,
                 "height": 142,
-                "left": -2567.5,
-                "right": -2367.5,
-                "top": 333,
+                "left": -1007.5,
+                "right": -807.5,
+                "top": -119.5,
                 "width": 200,
-                "x": -2567.5,
-                "y": 333
+                "x": -1007.5,
+                "y": -119.5
             },
             "post_job_actions": {},
             "tool_id": "join1",
             "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.3",
             "type": "tool",
-            "uuid": "18f697d7-8929-437d-bb60-cdfc997bb280",
+            "uuid": "9ee16d67-bbd0-4b40-ba61-dcc6b12c75d2",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "0d0d1d6a-d374-4e91-a2c7-75bb796fa9da"
+                    "uuid": "41747367-9d98-4eb7-bcf6-9325f090ffd8"
                 }
             ]
         },
@@ -729,26 +729,26 @@
                 }
             ],
             "position": {
-                "bottom": 497,
+                "bottom": -2.5,
                 "height": 92,
-                "left": -2289.5,
-                "right": -2089.5,
-                "top": 405,
+                "left": -729.5,
+                "right": -529.5,
+                "top": -94.5,
                 "width": 200,
-                "x": -2289.5,
-                "y": 405
+                "x": -729.5,
+                "y": -94.5
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
             "tool_state": "{\"columnList\": \"c1,c4\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "7374e788-54e0-422f-809c-c515924d528f",
+            "uuid": "e7ddd27d-1f26-4ed3-ad82-f293e4006c59",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "536fb4d5-7adb-4fe7-970e-bd8820c0855c"
+                    "uuid": "6b456bfd-e198-410b-8cbc-37c6bf629811"
                 }
             ]
         },
@@ -759,15 +759,15 @@
             "id": 16,
             "input_connections": {
                 "barcodes": {
-                    "id": 4,
+                    "id": 0,
                     "output_name": "output"
                 },
                 "cell_meta": {
-                    "id": 5,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "gene_meta": {
-                    "id": 11,
+                    "id": 10,
                     "output_name": "feature_annotation"
                 },
                 "genes": {
@@ -775,7 +775,7 @@
                     "output_name": "out_file1"
                 },
                 "matrix": {
-                    "id": 6,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -789,14 +789,14 @@
                 }
             ],
             "position": {
-                "bottom": 348,
+                "bottom": 311.5,
                 "height": 292,
-                "left": -2001.5,
-                "right": -1801.5,
-                "top": 56,
+                "left": -451.5,
+                "right": -251.5,
+                "top": 19.5,
                 "width": 200,
-                "x": -2001.5,
-                "y": 56
+                "x": -451.5,
+                "y": 19.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -827,7 +827,7 @@
             "tool_state": "{\"barcodes\": {\"__class__\": \"ConnectedValue\"}, \"cell_meta\": {\"__class__\": \"ConnectedValue\"}, \"gene_meta\": {\"__class__\": \"ConnectedValue\"}, \"genes\": {\"__class__\": \"ConnectedValue\"}, \"matrix\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"var_names\": \"gene_ids\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "9a05f13e-c9df-4fdd-b539-73749191709f",
+            "uuid": "a79f73e7-41c3-49c0-b893-6afac53be3fe",
             "workflow_outputs": []
         },
         "17": {
@@ -863,14 +863,14 @@
                 }
             ],
             "position": {
-                "bottom": 497,
+                "bottom": 460.5,
                 "height": 362,
-                "left": -1723.5,
-                "right": -1523.5,
-                "top": 135,
+                "left": -173.5,
+                "right": 26.5,
+                "top": 98.5,
                 "width": 200,
-                "x": -1723.5,
-                "y": 135
+                "x": -173.5,
+                "y": 98.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -909,7 +909,7 @@
             "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"gene_name\": \"gene_symbols\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_genes\", \"min\": \"400.0\", \"max\": \"1000000000.0\"}, {\"__index__\": 1, \"name\": \"n_counts\", \"min\": \"0.0\", \"max\": \"1000000000.0\"}], \"subsets\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "8e3edafe-82ef-47b4-b387-6931244ac0fb",
+            "uuid": "da752cb4-6258-4331-b8d4-328a85796f2e",
             "workflow_outputs": []
         },
         "18": {
@@ -923,7 +923,7 @@
                     "output_name": "output_h5ad"
                 },
                 "subsets_0|subset": {
-                    "id": 10,
+                    "id": 11,
                     "output_name": "feature_annotation"
                 }
             },
@@ -949,14 +949,14 @@
                 }
             ],
             "position": {
-                "bottom": 807,
+                "bottom": 774.5,
                 "height": 432,
-                "left": -1445.5,
-                "right": -1245.5,
-                "top": 375,
+                "left": 104.5,
+                "right": 304.5,
+                "top": 342.5,
                 "width": 200,
-                "x": -1445.5,
-                "y": 375
+                "x": 104.5,
+                "y": 342.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1001,28 +1001,28 @@
             "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_cells\", \"min\": \"3.0\", \"max\": \"1000000000.0\"}], \"subsets\": [{\"__index__\": 0, \"name\": \"index\", \"subset\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "0bf4093a-ad6d-453d-87fc-b14c6a5a0126",
+            "uuid": "7983f312-72ed-44dc-88bb-85fb66265828",
             "workflow_outputs": [
                 {
                     "label": null,
+                    "output_name": "genes_10x",
+                    "uuid": "db80fe93-14e2-4e62-ae51-55e0a474377d"
+                },
+                {
+                    "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "be8f9237-5788-4838-aa46-8a0e9ad8c4a5"
+                    "uuid": "532218f0-cc38-4700-b55d-8f75c7af474b"
                 },
                 {
                     "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "ac1e57b2-d597-4527-928e-f8a379d8eb09"
-                },
-                {
-                    "label": null,
-                    "output_name": "genes_10x",
-                    "uuid": "ee406952-b6c3-4687-be01-087b250f41ca"
+                    "uuid": "e25b1488-d152-4f78-b541-ee3a575fb347"
                 }
             ]
         },
         "19": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
             "errors": null,
             "id": 19,
             "input_connections": {
@@ -1031,62 +1031,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
-            "label": "normalise_data_internal",
-            "name": "Scanpy NormaliseData",
-            "outputs": [
+            "inputs": [
                 {
-                    "name": "output_h5ad",
-                    "type": "h5ad"
+                    "description": "runtime parameter for tool Scanpy NormaliseData",
+                    "name": "input_obj_file"
                 }
             ],
-            "position": {
-                "bottom": 687,
-                "height": 192,
-                "left": -1167.5,
-                "right": -967.5,
-                "top": 495,
-                "width": 200,
-                "x": -1167.5,
-                "y": 495
-            },
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
-                },
-                "HideDatasetActionoutput_h5ad": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_h5ad"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "463d4fa8f5ec",
-                "name": "scanpy_normalise_data",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"10000.0\", \"log_transform\": \"true\", \"save_raw\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy0",
-            "type": "tool",
-            "uuid": "7175010e-d7b9-47b3-97e3-1b1da2c2bc34",
-            "workflow_outputs": []
-        },
-        "20": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0",
-            "errors": null,
-            "id": 20,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 18,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [],
             "label": "normalise_data",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1108,21 +1058,16 @@
                 }
             ],
             "position": {
-                "bottom": 1107,
+                "bottom": 424.5,
                 "height": 382,
-                "left": -1167.5,
-                "right": -967.5,
-                "top": 725,
+                "left": 382.5,
+                "right": 582.5,
+                "top": 42.5,
                 "width": 200,
-                "x": -1167.5,
-                "y": 725
+                "x": 382.5,
+                "y": 42.5
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
-                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1150,34 +1095,89 @@
                     "output_name": "matrix_10x"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.6.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "463d4fa8f5ec",
+                "changeset_revision": "28ab1cdd0cf5",
                 "name": "scanpy_normalise_data",
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"save_raw\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy0",
+            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "10db47e3-d803-43f6-99ba-b2c852774527",
+            "uuid": "1233d97d-615f-4276-a0ce-fdb36ed06fe2",
             "workflow_outputs": [
                 {
                     "label": null,
+                    "output_name": "matrix_10x",
+                    "uuid": "3522a3ff-04ae-4984-b2f6-68942581aa64"
+                },
+                {
+                    "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "077c41c4-baf4-4b2d-895b-ce4f25d8f953"
+                    "uuid": "f295a290-a9ea-43c5-bd01-9eb8cae77ec0"
                 },
                 {
                     "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "f211b575-5303-4a1c-93cb-bc574d508a24"
-                },
-                {
-                    "label": null,
-                    "output_name": "matrix_10x",
-                    "uuid": "b537b29a-63c6-430f-8444-c4673065aa04"
+                    "uuid": "d5595cf0-8991-47c3-9614-98cfc5e7d0ce"
                 }
             ]
+        },
+        "20": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
+            "errors": null,
+            "id": 20,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 18,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy NormaliseData",
+                    "name": "input_obj_file"
+                }
+            ],
+            "label": "normalise_data_internal",
+            "name": "Scanpy NormaliseData",
+            "outputs": [
+                {
+                    "name": "output_h5ad",
+                    "type": "h5ad"
+                }
+            ],
+            "position": {
+                "bottom": 654.5,
+                "height": 192,
+                "left": 382.5,
+                "right": 582.5,
+                "top": 462.5,
+                "width": 200,
+                "x": 382.5,
+                "y": 462.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_h5ad"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "28ab1cdd0cf5",
+                "name": "scanpy_normalise_data",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.7.2+galaxy0",
+            "type": "tool",
+            "uuid": "d80c5460-9eb4-43b0-a2b3-e3ee1703830a",
+            "workflow_outputs": []
         },
         "21": {
             "annotation": "",
@@ -1186,7 +1186,7 @@
             "id": 21,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 19,
+                    "id": 20,
                     "output_name": "output_h5ad"
                 }
             },
@@ -1200,14 +1200,14 @@
                 }
             ],
             "position": {
-                "bottom": 687,
+                "bottom": 654.5,
                 "height": 192,
-                "left": -889.5,
-                "right": -689.5,
-                "top": 495,
+                "left": 660.5,
+                "right": 860.5,
+                "top": 462.5,
                 "width": 200,
-                "x": -889.5,
-                "y": 495
+                "x": 660.5,
+                "y": 462.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1231,7 +1231,7 @@
             "tool_state": "{\"batch_key\": \"\", \"filter\": \"false\", \"flavor\": \"seurat\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"max_disp\": \"50.0\", \"max_mean\": \"1000000000.0\", \"min_disp\": \"0.5\", \"min_mean\": \"0.0125\", \"n_bin\": \"20\", \"n_top_gene\": \"\", \"output_format\": \"anndata_h5ad\", \"span\": \"0.3\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "6fa6b2a2-3b55-43f0-8cd0-7be854f2086b",
+            "uuid": "acd1272b-3c87-49c5-b100-e12a832171cb",
             "workflow_outputs": []
         },
         "22": {
@@ -1255,14 +1255,14 @@
                 }
             ],
             "position": {
-                "bottom": 667,
+                "bottom": 634.5,
                 "height": 152,
-                "left": -611.5,
-                "right": -411.5,
-                "top": 515,
+                "left": 938.5,
+                "right": 1138.5,
+                "top": 482.5,
                 "width": 200,
-                "x": -611.5,
-                "y": 515
+                "x": 938.5,
+                "y": 482.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1281,7 +1281,7 @@
             "tool_state": "{\"extra_outputs\": null, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"n_pcs\": \"\", \"output_format\": \"anndata_h5ad\", \"run_mode\": {\"chunked\": \"false\", \"__current_case__\": 1, \"zero_center\": \"false\", \"svd_solver\": \"arpack\", \"random_seed\": \"1234\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
-            "uuid": "2ed9e300-8bcb-44c2-8d25-8c1e246e7a28",
+            "uuid": "725b1084-4ac3-4305-b1c9-31c55508b7da",
             "workflow_outputs": []
         },
         "23": {
@@ -1305,14 +1305,14 @@
                 }
             ],
             "position": {
-                "bottom": 687,
+                "bottom": 654.5,
                 "height": 192,
-                "left": -333.5,
-                "right": -133.5,
-                "top": 495,
+                "left": 1216.5,
+                "right": 1416.5,
+                "top": 462.5,
                 "width": 200,
-                "x": -333.5,
-                "y": 495
+                "x": 1216.5,
+                "y": 462.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1331,26 +1331,77 @@
             "tool_state": "{\"adjusted_basis\": \"X_pca\", \"basis\": \"X_pca\", \"batch_key\": \"BATCH_FIELD\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"true\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
-            "uuid": "46e2af6a-f979-4326-a3dd-387eec3b9f05",
+            "uuid": "e2ffe318-8ec1-4bce-aae9-24117b30ac40",
             "workflow_outputs": []
         },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
             "errors": null,
             "id": 24,
             "input_connections": {
                 "input_obj_file": {
                     "id": 23,
                     "output_name": "output_h5ad"
-                },
-                "settings|n_neighbors_file": {
-                    "id": 0,
-                    "output_name": "parameter_iteration"
                 }
             },
             "inputs": [],
-            "label": "neighbours for umap",
+            "label": "plot_pca",
+            "name": "Scanpy PlotEmbed",
+            "outputs": [
+                {
+                    "name": "output_png",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "bottom": 150.5,
+                "height": 152,
+                "left": 1494.5,
+                "right": 1694.5,
+                "top": -1.5,
+                "width": 200,
+                "x": 1494.5,
+                "y": -1.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_png": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_png"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "a8ef4bc35839",
+                "name": "scanpy_plot_embed",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"basis\": \"pca\", \"color_by\": \"n_genes\", \"components\": \"\", \"edges\": \"false\", \"edges_color\": \"\", \"edges_width\": \"0.1\", \"fig_dpi\": \"80\", \"fig_fontsize\": \"10\", \"fig_frame\": \"false\", \"fig_size\": \"7,7\", \"fig_title\": \"PCA\", \"gene_symbols_field\": \"\", \"groups\": \"\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"layer\": \"\", \"legend_fontsize\": \"10\", \"legend_loc\": \"right margin\", \"neighbors_key\": \"\", \"point_size\": \"\", \"projection\": \"2d\", \"sort_order\": \"false\", \"use_raw\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.6.0+galaxy0",
+            "type": "tool",
+            "uuid": "f9bd31d8-5eb9-450f-8d0b-cc422c9ffb80",
+            "workflow_outputs": []
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 23,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph",
+                    "name": "settings"
+                }
+            ],
+            "label": "neighbours",
             "name": "Scanpy ComputeGraph",
             "outputs": [
                 {
@@ -1359,26 +1410,19 @@
                 }
             ],
             "position": {
-                "bottom": 310,
-                "height": 262,
-                "left": -55.5,
-                "right": 144.5,
-                "top": 48,
+                "bottom": 430.5,
+                "height": 242,
+                "left": 1494.5,
+                "right": 1694.5,
+                "top": 188.5,
                 "width": 200,
-                "x": -55.5,
-                "y": 48
+                "x": 1494.5,
+                "y": 188.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "output_h5ad"
-                },
-                "RenameDatasetActionoutput_h5ad": {
-                    "action_arguments": {
-                        "newname": "#{n_neighbors_file}"
-                    },
-                    "action_type": "RenameDatasetAction",
                     "output_name": "output_h5ad"
                 }
             },
@@ -1389,24 +1433,24 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"ConnectedValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "15106e26-8656-4fc9-ab08-c20a7bbb9e49",
+            "uuid": "b3ccf81f-9897-4fa1-ac29-f8152d608c0e",
             "workflow_outputs": []
         },
-        "25": {
+        "26": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.6.0+galaxy2",
             "errors": null,
-            "id": 25,
+            "id": 26,
             "input_connections": {
                 "input_obj_file": {
                     "id": 23,
                     "output_name": "output_h5ad"
                 },
                 "settings|perplexity_file": {
-                    "id": 1,
+                    "id": 4,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -1424,14 +1468,14 @@
                 }
             ],
             "position": {
-                "bottom": 640,
+                "bottom": 879.5,
                 "height": 292,
-                "left": -55.5,
-                "right": 144.5,
-                "top": 348,
+                "left": 1494.5,
+                "right": 1694.5,
+                "top": 587.5,
                 "width": 200,
-                "x": -55.5,
-                "y": 348
+                "x": 1494.5,
+                "y": 587.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1464,64 +1508,14 @@
             "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"perplexity_PERPLEXITY\", \"perplexity\": \"30.0\", \"perplexity_file\": {\"__class__\": \"ConnectedValue\"}, \"early_exaggeration\": \"12.0\", \"learning_rate\": \"400.0\", \"fast_tsne\": \"false\", \"n_job\": \"\", \"n_pc\": \"\", \"random_seed\": \"1234\"}, \"use_rep\": \"auto\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy2",
             "type": "tool",
-            "uuid": "000dc762-69f5-4fb1-bfad-15efddc3f6a4",
+            "uuid": "11d2deeb-54e6-470a-8831-ba3f51209c19",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "d908bb78-fe07-4dfb-83ca-2fbc7471e895"
+                    "uuid": "6533e066-baa5-49f8-b43e-1f6d1e2cacdb"
                 }
             ]
-        },
-        "26": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "errors": null,
-            "id": 26,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 23,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [],
-            "label": "plot_pca",
-            "name": "Scanpy PlotEmbed",
-            "outputs": [
-                {
-                    "name": "output_png",
-                    "type": "png"
-                }
-            ],
-            "position": {
-                "bottom": 830,
-                "height": 152,
-                "left": -55.5,
-                "right": 144.5,
-                "top": 678,
-                "width": 200,
-                "x": -55.5,
-                "y": 678
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_png"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "a8ef4bc35839",
-                "name": "scanpy_plot_embed",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"basis\": \"pca\", \"color_by\": \"n_genes\", \"components\": \"\", \"edges\": \"false\", \"edges_color\": \"\", \"edges_width\": \"0.1\", \"fig_dpi\": \"80\", \"fig_fontsize\": \"10\", \"fig_frame\": \"false\", \"fig_size\": \"7,7\", \"fig_title\": \"PCA\", \"gene_symbols_field\": \"\", \"groups\": \"\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"layer\": \"\", \"legend_fontsize\": \"10\", \"legend_loc\": \"right margin\", \"neighbors_key\": \"\", \"point_size\": \"\", \"projection\": \"2d\", \"sort_order\": \"false\", \"use_raw\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy0",
-            "type": "tool",
-            "uuid": "27ea9c33-e5ec-4e17-be8d-c86fe0df35c2",
-            "workflow_outputs": []
         },
         "27": {
             "annotation": "",
@@ -1532,15 +1526,14 @@
                 "input_obj_file": {
                     "id": 23,
                     "output_name": "output_h5ad"
+                },
+                "settings|n_neighbors_file": {
+                    "id": 7,
+                    "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph",
-                    "name": "settings"
-                }
-            ],
-            "label": "neighbours",
+            "inputs": [],
+            "label": "neighbours for umap",
             "name": "Scanpy ComputeGraph",
             "outputs": [
                 {
@@ -1549,19 +1542,26 @@
                 }
             ],
             "position": {
-                "bottom": 1110,
-                "height": 242,
-                "left": -55.5,
-                "right": 144.5,
-                "top": 868,
+                "bottom": 1179.5,
+                "height": 262,
+                "left": 1494.5,
+                "right": 1694.5,
+                "top": 917.5,
                 "width": 200,
-                "x": -55.5,
-                "y": 868
+                "x": 1494.5,
+                "y": 917.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
+                    "output_name": "output_h5ad"
+                },
+                "RenameDatasetActionoutput_h5ad": {
+                    "action_arguments": {
+                        "newname": "#{n_neighbors_file}"
+                    },
+                    "action_type": "RenameDatasetAction",
                     "output_name": "output_h5ad"
                 }
             },
@@ -1572,141 +1572,20 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"ConnectedValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "6864184b-3a87-4f96-a75c-51949fc6a90a",
+            "uuid": "ec037e7b-8aca-4266-a267-0ef3ef5ac7d8",
             "workflow_outputs": []
         },
         "28": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1",
+            "content_id": "__BUILD_LIST__",
             "errors": null,
             "id": 28,
             "input_connections": {
-                "input_obj_file": {
-                    "id": 24,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [],
-            "label": "run_umap",
-            "name": "Scanpy RunUMAP",
-            "outputs": [
-                {
-                    "name": "output_h5",
-                    "type": "h5"
-                },
-                {
-                    "name": "output_embed",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 330,
-                "height": 222,
-                "left": 222.5,
-                "right": 422.5,
-                "top": 108,
-                "width": 200,
-                "x": 222.5,
-                "y": 108
-            },
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
-                },
-                "HideDatasetActionoutput_h5": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_h5"
-                },
-                "RenameDatasetActionoutput_embed": {
-                    "action_arguments": {
-                        "newname": "umap_#{input_obj_file}.tsv"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output_embed"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "abae3d11d920",
-                "name": "scanpy_run_umap",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"key_added\": \"NEIGHBORS_KEY\", \"output_format\": \"anndata\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"n_components\": \"2\", \"min_dist\": \"0.5\", \"spread\": \"1.0\", \"alpha\": \"1.0\", \"gamma\": \"1.0\", \"negative_sample_rate\": \"5\", \"init_pos\": \"spectral\", \"maxiter\": \"\", \"random_seed\": \"0\"}, \"use_graph\": \"neighbors_INPUT_OBJ\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy1",
-            "type": "tool",
-            "uuid": "a84344e4-50c9-4a6b-bc20-faa056f39fed",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output_embed",
-                    "uuid": "e4b52265-8895-49f6-a26c-4692de78a3cb"
-                }
-            ]
-        },
-        "29": {
-            "annotation": "",
-            "content_id": "__FILTER_FAILED_DATASETS__",
-            "errors": null,
-            "id": 29,
-            "input_connections": {
-                "input": {
-                    "id": 25,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Filter failed",
-                    "name": "input"
-                }
-            ],
-            "label": null,
-            "name": "Filter failed",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 550,
-                "height": 112,
-                "left": 500.5,
-                "right": 700.5,
-                "top": 438,
-                "width": 200,
-                "x": 500.5,
-                "y": 438
-            },
-            "post_job_actions": {},
-            "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "96905353-b241-4813-bf8f-47267cbdc71f",
-            "workflow_outputs": [
-                {
-                    "label": "input dataset(s) (filtered failed datasets)",
-                    "output_name": "output",
-                    "uuid": "8089a209-1db7-4080-a224-e2b19a709543"
-                }
-            ]
-        },
-        "30": {
-            "annotation": "",
-            "content_id": "__BUILD_LIST__",
-            "errors": null,
-            "id": 30,
-            "input_connections": {
                 "datasets_0|input": {
-                    "id": 27,
+                    "id": 25,
                     "output_name": "output_h5ad"
                 }
             },
@@ -1720,14 +1599,14 @@
                 }
             ],
             "position": {
-                "bottom": 877,
+                "bottom": 280.5,
                 "height": 112,
-                "left": 222.5,
-                "right": 422.5,
-                "top": 765,
+                "left": 1782.5,
+                "right": 1982.5,
+                "top": 168.5,
                 "width": 200,
-                "x": 222.5,
-                "y": 765
+                "x": 1782.5,
+                "y": 168.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1740,21 +1619,21 @@
             "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "997dad98-f04d-4f38-9199-87ae0905251c",
+            "uuid": "7a39daea-90cf-4bb5-a911-bdde42cf7811",
             "workflow_outputs": []
         },
-        "31": {
+        "29": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.6.0+galaxy3",
             "errors": null,
-            "id": 31,
+            "id": 29,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 27,
+                    "id": 25,
                     "output_name": "output_h5ad"
                 },
                 "settings|resolution_file": {
-                    "id": 3,
+                    "id": 5,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -1772,14 +1651,14 @@
                 }
             ],
             "position": {
-                "bottom": 1227,
+                "bottom": 630.5,
                 "height": 312,
-                "left": 222.5,
-                "right": 422.5,
-                "top": 915,
+                "left": 1782.5,
+                "right": 1982.5,
+                "top": 318.5,
                 "width": 200,
-                "x": 222.5,
-                "y": 915
+                "x": 1782.5,
+                "y": 318.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1812,32 +1691,27 @@
             "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"louvain\", \"output_cluster\": \"true\", \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"neighbors_key\": \"neighbors\", \"layer\": \"\", \"key_added\": \"METHOD_resolution_RESOLUTION\", \"resolution\": \"1.0\", \"resolution_file\": {\"__class__\": \"ConnectedValue\"}, \"restrict_to\": \"\", \"use_weights\": \"false\", \"random_seed\": \"1234\", \"directed\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "58aec931-0216-43b1-b4ab-177d3dc82a03",
+            "uuid": "cbde22a5-8040-4f80-98a9-873ff646bf67",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_txt",
-                    "uuid": "0a89004d-0a5d-435c-a1a0-ffc5802d0be9"
+                    "uuid": "b2518660-2b6c-48bd-a746-81bb218ba819"
                 }
             ]
         },
-        "32": {
+        "30": {
             "annotation": "",
             "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 32,
+            "id": 30,
             "input_connections": {
                 "input": {
-                    "id": 28,
-                    "output_name": "output_h5"
+                    "id": 26,
+                    "output_name": "output_h5ad"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Filter failed",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Filter failed",
             "outputs": [
@@ -1847,41 +1721,113 @@
                 }
             ],
             "position": {
-                "bottom": 275,
+                "bottom": 974.5,
                 "height": 112,
-                "left": 500.5,
-                "right": 700.5,
-                "top": 163,
+                "left": 2060.5,
+                "right": 2260.5,
+                "top": 862.5,
                 "width": 200,
-                "x": 500.5,
-                "y": 163
+                "x": 2060.5,
+                "y": 862.5
             },
             "post_job_actions": {},
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "b1127117-6848-40f2-a2ac-87087853c883",
+            "uuid": "0a6202a1-c823-4859-ba81-269390c4dcf6",
             "workflow_outputs": [
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "25820e65-44ac-405c-a86f-c2deddb51738"
+                    "uuid": "b2becc55-53e1-443e-8c29-95cb79d13faa"
                 }
             ]
         },
-        "33": {
+        "31": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1",
+            "errors": null,
+            "id": 31,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 27,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [],
+            "label": "run_umap",
+            "name": "Scanpy RunUMAP",
+            "outputs": [
+                {
+                    "name": "output_h5",
+                    "type": "h5"
+                },
+                {
+                    "name": "output_embed",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 1179.5,
+                "height": 222,
+                "left": 1782.5,
+                "right": 1982.5,
+                "top": 957.5,
+                "width": 200,
+                "x": 1782.5,
+                "y": 957.5
+            },
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5"
+                },
+                "HideDatasetActionoutput_h5": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_h5"
+                },
+                "RenameDatasetActionoutput_embed": {
+                    "action_arguments": {
+                        "newname": "umap_#{input_obj_file}.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_embed"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "abae3d11d920",
+                "name": "scanpy_run_umap",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"key_added\": \"NEIGHBORS_KEY\", \"output_format\": \"anndata\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"n_components\": \"2\", \"min_dist\": \"0.5\", \"spread\": \"1.0\", \"alpha\": \"1.0\", \"gamma\": \"1.0\", \"negative_sample_rate\": \"5\", \"init_pos\": \"spectral\", \"maxiter\": \"\", \"random_seed\": \"0\"}, \"use_graph\": \"neighbors_INPUT_OBJ\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.6.0+galaxy1",
+            "type": "tool",
+            "uuid": "0eb19400-dbff-403e-bc01-b44ba7e7d390",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_embed",
+                    "uuid": "0e6c6e8d-f43c-43e7-87bd-627ed4bbf82b"
+                }
+            ]
+        },
+        "32": {
             "annotation": "",
             "content_id": "__MERGE_COLLECTION__",
             "errors": null,
-            "id": 33,
+            "id": 32,
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 31,
+                    "id": 29,
                     "output_name": "output_h5ad"
                 },
                 "inputs_1|input": {
-                    "id": 30,
+                    "id": 28,
                     "output_name": "output"
                 }
             },
@@ -1895,14 +1841,14 @@
                 }
             ],
             "position": {
-                "bottom": 967,
+                "bottom": 538.5,
                 "height": 202,
-                "left": 500.5,
-                "right": 700.5,
-                "top": 765,
+                "left": 2060.5,
+                "right": 2260.5,
+                "top": 336.5,
                 "width": 200,
-                "x": 500.5,
-                "y": 765
+                "x": 2060.5,
+                "y": 336.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1915,27 +1861,23 @@
             "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "f871f625-2116-4f96-bcae-5c2775e36be7",
+            "uuid": "30d07b08-fe9d-4d21-8388-0795d35db7e1",
             "workflow_outputs": []
         },
-        "34": {
+        "33": {
             "annotation": "",
-            "content_id": "__MERGE_COLLECTION__",
+            "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 34,
+            "id": 33,
             "input_connections": {
-                "inputs_0|input": {
-                    "id": 29,
-                    "output_name": "output"
-                },
-                "inputs_1|input": {
-                    "id": 32,
-                    "output_name": "output"
+                "input": {
+                    "id": 31,
+                    "output_name": "output_h5"
                 }
             },
             "inputs": [],
-            "label": "merged_embeddings",
-            "name": "Merge Collections",
+            "label": null,
+            "name": "Filter failed",
             "outputs": [
                 {
                     "name": "output",
@@ -1943,46 +1885,41 @@
                 }
             ],
             "position": {
-                "bottom": 357,
-                "height": 202,
-                "left": 778.5,
-                "right": 978.5,
-                "top": 155,
+                "bottom": 1124.5,
+                "height": 112,
+                "left": 2060.5,
+                "right": 2260.5,
+                "top": 1012.5,
                 "width": 200,
-                "x": 778.5,
-                "y": 155
+                "x": 2060.5,
+                "y": 1012.5
             },
-            "post_job_actions": {
-                "DeleteIntermediatesActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output"
-                },
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__MERGE_COLLECTION__",
-            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "post_job_actions": {},
+            "tool_id": "__FILTER_FAILED_DATASETS__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "25131a8b-93f5-4134-b5b9-d8567a804260",
-            "workflow_outputs": []
+            "uuid": "2f3fde2d-6f52-45a7-8ca0-ba3ae1cccaf3",
+            "workflow_outputs": [
+                {
+                    "label": "input dataset(s) (filtered failed datasets)",
+                    "output_name": "output",
+                    "uuid": "e3d27964-869a-4b9a-b3df-f409f40fc6d4"
+                }
+            ]
         },
-        "35": {
+        "34": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy4",
             "errors": null,
-            "id": 35,
+            "id": 34,
             "input_connections": {
                 "groupby_file": {
                     "id": 13,
                     "output_name": "output"
                 },
                 "input_obj_file": {
-                    "id": 33,
+                    "id": 32,
                     "output_name": "output"
                 }
             },
@@ -2000,14 +1937,14 @@
                 }
             ],
             "position": {
-                "bottom": 1089,
+                "bottom": 660.5,
                 "height": 292,
-                "left": 778.5,
-                "right": 978.5,
-                "top": 797,
+                "left": 2338.5,
+                "right": 2538.5,
+                "top": 368.5,
                 "width": 200,
-                "x": 778.5,
-                "y": 797
+                "x": 2338.5,
+                "y": 368.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -2033,14 +1970,67 @@
             "tool_state": "{\"groupby\": \"INPUT_OBJ\", \"groupby_file\": {\"__class__\": \"ConnectedValue\"}, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"n_genes\": \"100\", \"output_format\": \"anndata_h5ad\", \"output_markers\": \"true\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"markers_GROUPBY\", \"method\": \"t-test_overestim_var\", \"use_raw\": \"true\", \"rankby_abs\": \"false\", \"groups\": \"\", \"reference\": \"rest\", \"min_in_group_fraction\": \"0.0\", \"max_out_group_fraction\": \"1.0\", \"min_fold_change\": \"1.0\", \"pts\": \"false\", \"tie_correct\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy4",
             "type": "tool",
-            "uuid": "e961706f-2b0c-4640-bfaf-06d6869e876e",
+            "uuid": "c88a0424-a813-410a-a042-83326fa3ebbd",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_tsv",
-                    "uuid": "89e8962e-92ca-434e-9776-914aa012f803"
+                    "uuid": "9c6b1b69-f80c-4bfe-a845-21caf3ea56ac"
                 }
             ]
+        },
+        "35": {
+            "annotation": "",
+            "content_id": "__MERGE_COLLECTION__",
+            "errors": null,
+            "id": 35,
+            "input_connections": {
+                "inputs_0|input": {
+                    "id": 30,
+                    "output_name": "output"
+                },
+                "inputs_1|input": {
+                    "id": 33,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": "merged_embeddings",
+            "name": "Merge Collections",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 1132.5,
+                "height": 202,
+                "left": 2338.5,
+                "right": 2538.5,
+                "top": 930.5,
+                "width": 200,
+                "x": 2338.5,
+                "y": 930.5
+            },
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__MERGE_COLLECTION__",
+            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "02f93344-d954-4a14-a8de-5482ea7adbd0",
+            "workflow_outputs": []
         },
         "36": {
             "annotation": "",
@@ -2049,7 +2039,7 @@
             "id": 36,
             "input_connections": {
                 "input": {
-                    "id": 35,
+                    "id": 34,
                     "output_name": "output_h5ad"
                 }
             },
@@ -2063,14 +2053,14 @@
                 }
             ],
             "position": {
-                "bottom": 931,
+                "bottom": 580.5,
                 "height": 132,
-                "left": 1056.5,
-                "right": 1256.5,
-                "top": 799,
+                "left": 2616.5,
+                "right": 2816.5,
+                "top": 448.5,
                 "width": 200,
-                "x": 1056.5,
-                "y": 799
+                "x": 2616.5,
+                "y": 448.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2088,29 +2078,37 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "b7d0c5e5-65c5-4366-96aa-21c6653e6399",
+            "uuid": "ed346e6d-aadb-4dbf-a23a-86a1714aea5f",
             "workflow_outputs": []
         },
         "37": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.6.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.7.2+galaxy0",
             "errors": null,
             "id": 37,
             "input_connections": {
                 "copy_e|embedding_sources": {
-                    "id": 34,
+                    "id": 35,
                     "output_name": "output"
                 },
                 "copy_o|obs_sources": {
                     "id": 36,
                     "output_name": "output"
                 },
+                "copy_r|r_source": {
+                    "id": 16,
+                    "output_name": "output_h5ad"
+                },
                 "copy_u|uns_sources": {
                     "id": 36,
                     "output_name": "output"
                 },
+                "copy_x|xlayers_0|x_source": {
+                    "id": 18,
+                    "output_name": "output_h5ad"
+                },
                 "input_obj_file": {
-                    "id": 27,
+                    "id": 25,
                     "output_name": "output_h5ad"
                 }
             },
@@ -2124,14 +2122,14 @@
                 }
             ],
             "position": {
-                "bottom": 976,
-                "height": 342,
-                "left": 1334.5,
-                "right": 1534.5,
-                "top": 634,
+                "bottom": 765.5,
+                "height": 502,
+                "left": 2904.5,
+                "right": 3104.5,
+                "top": 263.5,
                 "width": 200,
-                "x": 1334.5,
-                "y": 634
+                "x": 2904.5,
+                "y": 263.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -2142,27 +2140,27 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.6.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.7.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "6aa025ea64d3",
+                "changeset_revision": "e4bb4666449e",
                 "name": "anndata_ops",
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"copy_adata_to_raw\": \"false\", \"copy_e\": {\"default\": \"true\", \"__current_case__\": 0, \"embedding_keys\": [{\"__index__\": 0, \"contains\": \"tsne\"}, {\"__index__\": 1, \"contains\": \"umap\"}], \"embedding_sources\": {\"__class__\": \"ConnectedValue\"}}, \"copy_o\": {\"default\": \"true\", \"__current_case__\": 0, \"obs_keys\": [{\"__index__\": 0, \"contains\": \"louvain\"}], \"obs_sources\": {\"__class__\": \"ConnectedValue\"}}, \"copy_u\": {\"default\": \"true\", \"__current_case__\": 0, \"uns_keys\": [{\"__index__\": 0, \"contains\": \"marker\"}], \"uns_sources\": {\"__class__\": \"ConnectedValue\"}}, \"gene_flags\": [], \"gene_symbols_field\": \"index\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"modifications\": [], \"output_format\": \"anndata_h5ad\", \"sanitize_varm\": \"false\", \"top_genes\": \"50\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy1",
+            "tool_state": "{\"copy_adata_to_raw\": \"false\", \"copy_e\": {\"default\": \"true\", \"__current_case__\": 0, \"embedding_keys\": [{\"__index__\": 0, \"contains\": \"tsne\"}, {\"__index__\": 1, \"contains\": \"umap\"}], \"embedding_sources\": {\"__class__\": \"ConnectedValue\"}}, \"copy_l\": {\"default\": \"false\", \"__current_case__\": 1}, \"copy_o\": {\"default\": \"true\", \"__current_case__\": 0, \"obs_keys\": [{\"__index__\": 0, \"contains\": \"louvain\"}], \"obs_sources\": {\"__class__\": \"ConnectedValue\"}}, \"copy_r\": {\"default\": \"true\", \"__current_case__\": 0, \"r_source\": {\"__class__\": \"ConnectedValue\"}}, \"copy_u\": {\"default\": \"true\", \"__current_case__\": 0, \"uns_keys\": [{\"__index__\": 0, \"contains\": \"marker\"}], \"uns_sources\": {\"__class__\": \"ConnectedValue\"}}, \"copy_x\": {\"default\": \"true\", \"__current_case__\": 0, \"xlayers\": [{\"__index__\": 0, \"x_source\": {\"__class__\": \"ConnectedValue\"}, \"dest\": \"filtered\"}]}, \"gene_flags\": [], \"gene_symbols_field\": \"index\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"modifications\": [], \"output_format\": \"anndata_h5ad\", \"sanitize_varm\": \"false\", \"top_genes\": \"50\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "1d63bee4-36c0-47a1-80b7-171cec08efcd",
+            "uuid": "cf72975e-7a8a-4e5f-ba3e-400e085b269b",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_h5ad",
-                    "uuid": "1acfe986-280e-4197-bc0f-396e7797af9e"
+                    "uuid": "a66f250f-1687-41a0-b2cc-e569beee5c9b"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "72ecc69d-7acc-499b-8748-658eb2bf48cb",
-    "version": 1
+    "uuid": "1cb50341-1cbc-4e15-a8d6-71f312a806ee",
+    "version": 9
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -13,32 +13,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "cellmeta"
+                    "name": "matrix"
                 }
             ],
-            "label": "cellmeta",
+            "label": "matrix",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 51,
+                "bottom": 412.5,
                 "height": 61,
-                "left": -649.5,
-                "right": -449.5,
-                "top": -10,
+                "left": -623.5,
+                "right": -423.5,
+                "top": 351.5,
                 "width": 200,
-                "x": -649.5,
-                "y": -10
+                "x": -623.5,
+                "y": 351.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
+            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "f4cce2c2-23a7-4b34-8e27-f2abd4db0dec"
+                    "uuid": "5bca189e-a1aa-46da-8a20-6f6c25212e34"
                 }
             ]
         },
@@ -51,32 +51,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "matrix"
+                    "name": "cellmeta"
                 }
             ],
-            "label": "matrix",
+            "label": "cellmeta",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 150,
+                "bottom": 511.5,
                 "height": 61,
-                "left": -649.5,
-                "right": -449.5,
-                "top": 89,
+                "left": -623.5,
+                "right": -423.5,
+                "top": 450.5,
                 "width": 200,
-                "x": -649.5,
-                "y": 89
+                "x": -623.5,
+                "y": 450.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
+            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "f8485ce8-6cb5-492b-bcbe-ff68a2682daa"
+                    "uuid": "51456688-b340-47a4-8eda-7469dfc18cc0"
                 }
             ]
         },
@@ -96,14 +96,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": -48,
+                "bottom": 610.5,
                 "height": 61,
-                "left": -649.5,
-                "right": -449.5,
-                "top": -109,
+                "left": -623.5,
+                "right": -423.5,
+                "top": 549.5,
                 "width": 200,
-                "x": -649.5,
-                "y": -109
+                "x": -623.5,
+                "y": 549.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -114,7 +114,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "2aab33fc-c24a-4105-b437-8c151ecb0aaa"
+                    "uuid": "e44cb7cf-0e7a-4fd8-a551-2e7fdd1c9968"
                 }
             ]
         },
@@ -134,14 +134,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": -55,
+                "bottom": 429.5,
                 "height": 61,
-                "left": -1205.5,
-                "right": -1005.5,
-                "top": -116,
+                "left": -1179.5,
+                "right": -979.5,
+                "top": 368.5,
                 "width": 200,
-                "x": -1205.5,
-                "y": -116
+                "x": -1179.5,
+                "y": 368.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -152,7 +152,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "0846d6ca-3046-491b-818f-63c9f33fd92c"
+                    "uuid": "1d8f3d25-f4a0-4cc3-ad7a-6f24d989eb45"
                 }
             ]
         },
@@ -172,14 +172,14 @@
                 }
             ],
             "position": {
-                "bottom": 629,
+                "bottom": 418.5,
                 "height": 81,
-                "left": 1296.5,
-                "right": 1496.5,
-                "top": 548,
+                "left": 1332.5,
+                "right": 1532.5,
+                "top": 337.5,
                 "width": 200,
-                "x": 1296.5,
-                "y": 548
+                "x": 1332.5,
+                "y": 337.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -208,47 +208,9 @@
         },
         "5": {
             "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 5,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "gtf"
-                }
-            ],
-            "label": "gtf",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 199,
-                "height": 61,
-                "left": -1483.5,
-                "right": -1283.5,
-                "top": 138,
-                "width": 200,
-                "x": -1483.5,
-                "y": 138
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "5c96ad77-57e0-4f62-b885-0251e0907dca"
-                }
-            ]
-        },
-        "6": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
             "errors": null,
-            "id": 6,
+            "id": 5,
             "input_connections": {},
             "inputs": [],
             "label": "n_neighbors",
@@ -260,14 +222,14 @@
                 }
             ],
             "position": {
-                "bottom": 991,
+                "bottom": 655.5,
                 "height": 81,
-                "left": 1296.5,
-                "right": 1496.5,
-                "top": 910,
+                "left": 1332.5,
+                "right": 1532.5,
+                "top": 574.5,
                 "width": 200,
-                "x": 1296.5,
-                "y": 910
+                "x": 1332.5,
+                "y": 574.5
             },
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -289,6 +251,44 @@
             "uuid": "5e22d4cd-71d6-4a91-b326-508494138b82",
             "workflow_outputs": []
         },
+        "6": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 6,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "gtf"
+                }
+            ],
+            "label": "gtf",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 275.5,
+                "height": 61,
+                "left": -1457.5,
+                "right": -1257.5,
+                "top": 214.5,
+                "width": 200,
+                "x": -1457.5,
+                "y": 214.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "9c89e3b1-1281-4187-b0a9-e346cc300f22"
+                }
+            ]
+        },
         "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
@@ -305,14 +305,14 @@
                 }
             ],
             "position": {
-                "bottom": 405,
+                "bottom": 54.5,
                 "height": 81,
-                "left": 1574.5,
-                "right": 1774.5,
-                "top": 324,
+                "left": 1620.5,
+                "right": 1820.5,
+                "top": -26.5,
                 "width": 200,
-                "x": 1574.5,
-                "y": 324
+                "x": 1620.5,
+                "y": -26.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -355,14 +355,14 @@
                 }
             ],
             "position": {
-                "bottom": 605,
+                "bottom": 439.5,
                 "height": 81,
-                "left": 1862.5,
-                "right": 2062.5,
-                "top": 524,
+                "left": 1908.5,
+                "right": 2108.5,
+                "top": 358.5,
                 "width": 200,
-                "x": 1862.5,
-                "y": 524
+                "x": 1908.5,
+                "y": 358.5
             },
             "post_job_actions": {
                 "HideDatasetActionparameter_iteration": {
@@ -391,7 +391,7 @@
             "id": 9,
             "input_connections": {
                 "gtf_input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -405,71 +405,14 @@
                 }
             ],
             "position": {
-                "bottom": 235,
+                "bottom": 311.5,
                 "height": 132,
-                "left": -927.5,
-                "right": -727.5,
-                "top": 103,
+                "left": -335.5,
+                "right": -135.5,
+                "top": 179.5,
                 "width": 200,
-                "x": -927.5,
-                "y": 103
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionfeature_annotation": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "feature_annotation"
-                },
-                "HideDatasetActionfeature_annotation": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "feature_annotation"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "tool_shed_repository": {
-                "changeset_revision": "b6354c917ef9",
-                "name": "gtf2gene_list",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.42.1+galaxy4",
-            "type": "tool",
-            "uuid": "5c0d8c50-7891-4dc6-826f-0e5a6d3117bb",
-            "workflow_outputs": []
-        },
-        "10": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
-            "errors": null,
-            "id": 10,
-            "input_connections": {
-                "gtf_input": {
-                    "id": 5,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "GTF2GeneList",
-            "outputs": [
-                {
-                    "name": "feature_annotation",
-                    "type": "tsv"
-                }
-            ],
-            "position": {
-                "bottom": 405,
-                "height": 132,
-                "left": -927.5,
-                "right": -727.5,
-                "top": 273,
-                "width": 200,
-                "x": -927.5,
-                "y": 273
+                "x": -335.5,
+                "y": 179.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -498,14 +441,14 @@
             "uuid": "a341aa66-f857-49b2-9614-a7231237d5ce",
             "workflow_outputs": []
         },
-        "11": {
+        "10": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
             "errors": null,
-            "id": 11,
+            "id": 10,
             "input_connections": {
                 "gtf_input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -519,14 +462,71 @@
                 }
             ],
             "position": {
-                "bottom": -154,
+                "bottom": 397.5,
                 "height": 132,
-                "left": -1205.5,
-                "right": -1005.5,
-                "top": -286,
+                "left": -901.5,
+                "right": -701.5,
+                "top": 265.5,
                 "width": 200,
-                "x": -1205.5,
-                "y": -286
+                "x": -901.5,
+                "y": 265.5
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionfeature_annotation": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "HideDatasetActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "feature_annotation"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "b6354c917ef9",
+                "name": "gtf2gene_list",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.42.1+galaxy4",
+            "type": "tool",
+            "uuid": "5c0d8c50-7891-4dc6-826f-0e5a6d3117bb",
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/gtf2gene_list/_ensembl_gtf2gene_list/1.42.1+galaxy4",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "gtf_input": {
+                    "id": 6,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "GTF2GeneList",
+            "outputs": [
+                {
+                    "name": "feature_annotation",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "bottom": 599.5,
+                "height": 132,
+                "left": -1179.5,
+                "right": -979.5,
+                "top": 467.5,
+                "width": 200,
+                "x": -1179.5,
+                "y": 467.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -576,14 +576,14 @@
                 }
             ],
             "position": {
-                "bottom": 755,
+                "bottom": 320.5,
                 "height": 112,
-                "left": 1862.5,
-                "right": 2062.5,
-                "top": 643,
+                "left": 1908.5,
+                "right": 2108.5,
+                "top": 208.5,
                 "width": 200,
-                "x": 1862.5,
-                "y": 643
+                "x": 1908.5,
+                "y": 208.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -637,14 +637,14 @@
                 }
             ],
             "position": {
-                "bottom": -122,
+                "bottom": 577.5,
                 "height": 142,
-                "left": -927.5,
-                "right": -727.5,
-                "top": -264,
+                "left": -901.5,
+                "right": -701.5,
+                "top": 435.5,
                 "width": 200,
-                "x": -927.5,
-                "y": -264
+                "x": -901.5,
+                "y": 435.5
             },
             "post_job_actions": {},
             "tool_id": "join1",
@@ -656,7 +656,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "35396344-fc2f-41f6-a9cc-7e2d3726c45c"
+                    "uuid": "ea000a47-9e5d-449c-a927-7a46efc02a3c"
                 }
             ]
         },
@@ -685,14 +685,14 @@
                 }
             ],
             "position": {
-                "bottom": 680,
+                "bottom": 364.5,
                 "height": 202,
-                "left": 2140.5,
-                "right": 2340.5,
-                "top": 478,
+                "left": 2186.5,
+                "right": 2386.5,
+                "top": 162.5,
                 "width": 200,
-                "x": 2140.5,
-                "y": 478
+                "x": 2186.5,
+                "y": 162.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -729,14 +729,14 @@
                 }
             ],
             "position": {
-                "bottom": -147,
+                "bottom": 740.5,
                 "height": 92,
-                "left": -649.5,
-                "right": -449.5,
-                "top": -239,
+                "left": -623.5,
+                "right": -423.5,
+                "top": 648.5,
                 "width": 200,
-                "x": -649.5,
-                "y": -239
+                "x": -623.5,
+                "y": 648.5
             },
             "post_job_actions": {},
             "tool_id": "Cut1",
@@ -748,7 +748,7 @@
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "ae458424-e137-4750-a62e-951799b25028"
+                    "uuid": "9d57ba04-3d54-4d84-8789-2389c506fc91"
                 }
             ]
         },
@@ -763,11 +763,11 @@
                     "output_name": "output"
                 },
                 "cell_meta": {
-                    "id": 0,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "gene_meta": {
-                    "id": 9,
+                    "id": 10,
                     "output_name": "feature_annotation"
                 },
                 "genes": {
@@ -775,7 +775,7 @@
                     "output_name": "out_file1"
                 },
                 "matrix": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
@@ -789,14 +789,14 @@
                 }
             ],
             "position": {
-                "bottom": 167,
+                "bottom": 641.5,
                 "height": 292,
-                "left": -371.5,
-                "right": -171.5,
-                "top": -125,
+                "left": -335.5,
+                "right": -135.5,
+                "top": 349.5,
                 "width": 200,
-                "x": -371.5,
-                "y": -125
+                "x": -335.5,
+                "y": 349.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -863,14 +863,14 @@
                 }
             ],
             "position": {
-                "bottom": 316,
+                "bottom": 730.5,
                 "height": 362,
-                "left": -93.5,
-                "right": 106.5,
-                "top": -46,
+                "left": -57.5,
+                "right": 142.5,
+                "top": 368.5,
                 "width": 200,
-                "x": -93.5,
-                "y": -46
+                "x": -57.5,
+                "y": 368.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -923,7 +923,7 @@
                     "output_name": "output_h5ad"
                 },
                 "subsets_0|subset": {
-                    "id": 10,
+                    "id": 9,
                     "output_name": "feature_annotation"
                 }
             },
@@ -949,14 +949,14 @@
                 }
             ],
             "position": {
-                "bottom": 630,
+                "bottom": 611.5,
                 "height": 432,
-                "left": 184.5,
-                "right": 384.5,
-                "top": 198,
+                "left": 220.5,
+                "right": 420.5,
+                "top": 179.5,
                 "width": 200,
-                "x": 184.5,
-                "y": 198
+                "x": 220.5,
+                "y": 179.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1006,17 +1006,17 @@
                 {
                     "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "6b7d96f6-dc79-4501-b7b4-69cf6be9761d"
+                    "uuid": "78442981-8284-4ad3-bdf8-945feb54a663"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "632aa28d-b641-483a-b9f0-a43ac36dbd8c"
+                    "uuid": "54b40224-f965-44ab-928b-7b65791511ae"
                 },
                 {
                     "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "dedb6146-8cc3-4983-a88b-ff63b0bcaefe"
+                    "uuid": "7c04db19-8a08-4b94-91fd-389eb14d378e"
                 }
             ]
         },
@@ -1025,6 +1025,56 @@
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
             "errors": null,
             "id": 19,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 18,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [],
+            "label": "normalise_data_internal",
+            "name": "Scanpy NormaliseData",
+            "outputs": [
+                {
+                    "name": "output_h5ad",
+                    "type": "h5ad"
+                }
+            ],
+            "position": {
+                "bottom": 299.5,
+                "height": 192,
+                "left": 498.5,
+                "right": 698.5,
+                "top": 107.5,
+                "width": 200,
+                "x": 498.5,
+                "y": 107.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_h5ad"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "28ab1cdd0cf5",
+                "name": "scanpy_normalise_data",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.7.2+galaxy0",
+            "type": "tool",
+            "uuid": "115fd89d-67e2-4256-91df-a056a03c16a0",
+            "workflow_outputs": []
+        },
+        "20": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
+            "errors": null,
+            "id": 20,
             "input_connections": {
                 "input_obj_file": {
                     "id": 18,
@@ -1053,14 +1103,14 @@
                 }
             ],
             "position": {
-                "bottom": 280,
+                "bottom": 719.5,
                 "height": 382,
-                "left": 462.5,
-                "right": 662.5,
-                "top": -102,
+                "left": 498.5,
+                "right": 698.5,
+                "top": 337.5,
                 "width": 200,
-                "x": 462.5,
-                "y": -102
+                "x": 498.5,
+                "y": 337.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1104,75 +1154,20 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "barcodes_10x",
-                    "uuid": "3b15d77d-2a2b-472b-b450-aca8f54f45f1"
-                },
-                {
-                    "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "a21bdef9-8e4e-43dd-9650-a42d1237539b"
+                    "uuid": "2eae1269-5b75-4296-9b48-a4706deebe81"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "e56049fa-087a-4f8a-bd0d-e1c2ab7107f0"
+                    "uuid": "1bbdb614-62ca-47a8-9125-bdfb58763e57"
+                },
+                {
+                    "label": null,
+                    "output_name": "barcodes_10x",
+                    "uuid": "1c19bea1-f864-4e97-bfaf-b931b736609c"
                 }
             ]
-        },
-        "20": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
-            "errors": null,
-            "id": 20,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 18,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy NormaliseData",
-                    "name": "input_obj_file"
-                }
-            ],
-            "label": "normalise_data_internal",
-            "name": "Scanpy NormaliseData",
-            "outputs": [
-                {
-                    "name": "output_h5ad",
-                    "type": "h5ad"
-                }
-            ],
-            "position": {
-                "bottom": 510,
-                "height": 192,
-                "left": 462.5,
-                "right": 662.5,
-                "top": 318,
-                "width": 200,
-                "x": 462.5,
-                "y": 318
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_h5ad": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_h5ad"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "28ab1cdd0cf5",
-                "name": "scanpy_normalise_data",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.7.2+galaxy0",
-            "type": "tool",
-            "uuid": "115fd89d-67e2-4256-91df-a056a03c16a0",
-            "workflow_outputs": []
         },
         "21": {
             "annotation": "",
@@ -1181,7 +1176,7 @@
             "id": 21,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 20,
+                    "id": 19,
                     "output_name": "output_h5ad"
                 }
             },
@@ -1195,14 +1190,14 @@
                 }
             ],
             "position": {
-                "bottom": 510,
+                "bottom": 299.5,
                 "height": 192,
-                "left": 740.5,
-                "right": 940.5,
-                "top": 318,
+                "left": 776.5,
+                "right": 976.5,
+                "top": 107.5,
                 "width": 200,
-                "x": 740.5,
-                "y": 318
+                "x": 776.5,
+                "y": 107.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1250,14 +1245,14 @@
                 }
             ],
             "position": {
-                "bottom": 490,
+                "bottom": 279.5,
                 "height": 152,
-                "left": 1018.5,
-                "right": 1218.5,
-                "top": 338,
+                "left": 1054.5,
+                "right": 1254.5,
+                "top": 127.5,
                 "width": 200,
-                "x": 1018.5,
-                "y": 338
+                "x": 1054.5,
+                "y": 127.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1300,14 +1295,14 @@
                 }
             ],
             "position": {
-                "bottom": 510,
+                "bottom": 299.5,
                 "height": 192,
-                "left": 1296.5,
-                "right": 1496.5,
-                "top": 318,
+                "left": 1332.5,
+                "right": 1532.5,
+                "top": 107.5,
                 "width": 200,
-                "x": 1296.5,
-                "y": 318
+                "x": 1332.5,
+                "y": 107.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1331,114 +1326,9 @@
         },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
-            "errors": null,
-            "id": 24,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 23,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Scanpy ComputeGraph",
-                    "name": "settings"
-                }
-            ],
-            "label": "neighbours",
-            "name": "Scanpy ComputeGraph",
-            "outputs": [
-                {
-                    "name": "output_h5ad",
-                    "type": "h5ad"
-                }
-            ],
-            "position": {
-                "bottom": 286,
-                "height": 242,
-                "left": 1574.5,
-                "right": 1774.5,
-                "top": 44,
-                "width": 200,
-                "x": 1574.5,
-                "y": 44
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_h5ad": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_h5ad"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "3cf0177ed87e",
-                "name": "scanpy_compute_graph",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy3",
-            "type": "tool",
-            "uuid": "b3ccf81f-9897-4fa1-ac29-f8152d608c0e",
-            "workflow_outputs": []
-        },
-        "25": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "errors": null,
-            "id": 25,
-            "input_connections": {
-                "input_obj_file": {
-                    "id": 23,
-                    "output_name": "output_h5ad"
-                }
-            },
-            "inputs": [],
-            "label": "plot_pca",
-            "name": "Scanpy PlotEmbed",
-            "outputs": [
-                {
-                    "name": "output_png",
-                    "type": "png"
-                }
-            ],
-            "position": {
-                "bottom": 6,
-                "height": 152,
-                "left": 1574.5,
-                "right": 1774.5,
-                "top": -146,
-                "width": 200,
-                "x": 1574.5,
-                "y": -146
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_png": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_png"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_plot_embed/scanpy_plot_embed/1.6.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "a8ef4bc35839",
-                "name": "scanpy_plot_embed",
-                "owner": "ebi-gxa",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"basis\": \"pca\", \"color_by\": \"n_genes\", \"components\": \"\", \"edges\": \"false\", \"edges_color\": \"\", \"edges_width\": \"0.1\", \"fig_dpi\": \"80\", \"fig_fontsize\": \"10\", \"fig_frame\": \"false\", \"fig_size\": \"7,7\", \"fig_title\": \"PCA\", \"gene_symbols_field\": \"\", \"groups\": \"\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"layer\": \"\", \"legend_fontsize\": \"10\", \"legend_loc\": \"right margin\", \"neighbors_key\": \"\", \"point_size\": \"\", \"projection\": \"2d\", \"sort_order\": \"false\", \"use_raw\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.6.0+galaxy0",
-            "type": "tool",
-            "uuid": "f9bd31d8-5eb9-450f-8d0b-cc422c9ffb80",
-            "workflow_outputs": []
-        },
-        "26": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_tsne/scanpy_run_tsne/1.6.0+galaxy2",
             "errors": null,
-            "id": 26,
+            "id": 24,
             "input_connections": {
                 "input_obj_file": {
                     "id": 23,
@@ -1463,14 +1353,14 @@
                 }
             ],
             "position": {
-                "bottom": 735,
+                "bottom": 399.5,
                 "height": 292,
-                "left": 1574.5,
-                "right": 1774.5,
-                "top": 443,
+                "left": 1620.5,
+                "right": 1820.5,
+                "top": 107.5,
                 "width": 200,
-                "x": 1574.5,
-                "y": 443
+                "x": 1620.5,
+                "y": 107.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1508,22 +1398,77 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "ed1dd9d6-ef2c-4b0e-beb4-86cdab238902"
+                    "uuid": "e686c16c-82c4-4930-9dca-3ea921c98c19"
                 }
             ]
         },
-        "27": {
+        "25": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
             "errors": null,
-            "id": 27,
+            "id": 25,
+            "input_connections": {
+                "input_obj_file": {
+                    "id": 23,
+                    "output_name": "output_h5ad"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph",
+                    "name": "settings"
+                }
+            ],
+            "label": "neighbours",
+            "name": "Scanpy ComputeGraph",
+            "outputs": [
+                {
+                    "name": "output_h5ad",
+                    "type": "h5ad"
+                }
+            ],
+            "position": {
+                "bottom": -114.5,
+                "height": 242,
+                "left": 1620.5,
+                "right": 1820.5,
+                "top": -356.5,
+                "width": 200,
+                "x": 1620.5,
+                "y": -356.5
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_h5ad"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "3cf0177ed87e",
+                "name": "scanpy_compute_graph",
+                "owner": "ebi-gxa",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.6.0+galaxy3",
+            "type": "tool",
+            "uuid": "b3ccf81f-9897-4fa1-ac29-f8152d608c0e",
+            "workflow_outputs": []
+        },
+        "26": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_compute_graph/scanpy_compute_graph/1.6.0+galaxy3",
+            "errors": null,
+            "id": 26,
             "input_connections": {
                 "input_obj_file": {
                     "id": 23,
                     "output_name": "output_h5ad"
                 },
                 "settings|n_neighbors_file": {
-                    "id": 6,
+                    "id": 5,
                     "output_name": "parameter_iteration"
                 }
             },
@@ -1537,14 +1482,14 @@
                 }
             ],
             "position": {
-                "bottom": 1035,
+                "bottom": 699.5,
                 "height": 262,
-                "left": 1574.5,
-                "right": 1774.5,
-                "top": 773,
+                "left": 1620.5,
+                "right": 1820.5,
+                "top": 437.5,
                 "width": 200,
-                "x": 1574.5,
-                "y": 773
+                "x": 1620.5,
+                "y": 437.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1573,20 +1518,20 @@
             "uuid": "ec037e7b-8aca-4266-a267-0ef3ef5ac7d8",
             "workflow_outputs": []
         },
-        "28": {
+        "27": {
             "annotation": "",
-            "content_id": "__BUILD_LIST__",
+            "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 28,
+            "id": 27,
             "input_connections": {
-                "datasets_0|input": {
+                "input": {
                     "id": 24,
                     "output_name": "output_h5ad"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Build List",
+            "name": "Filter failed",
             "outputs": [
                 {
                     "name": "output",
@@ -1594,37 +1539,37 @@
                 }
             ],
             "position": {
-                "bottom": 136,
+                "bottom": 514.5,
                 "height": 112,
-                "left": 1862.5,
-                "right": 2062.5,
-                "top": 24,
+                "left": 2186.5,
+                "right": 2386.5,
+                "top": 402.5,
                 "width": 200,
-                "x": 1862.5,
-                "y": 24
+                "x": 2186.5,
+                "y": 402.5
             },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__BUILD_LIST__",
-            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "post_job_actions": {},
+            "tool_id": "__FILTER_FAILED_DATASETS__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "7a39daea-90cf-4bb5-a911-bdde42cf7811",
-            "workflow_outputs": []
+            "uuid": "0a6202a1-c823-4859-ba81-269390c4dcf6",
+            "workflow_outputs": [
+                {
+                    "label": "input dataset(s) (filtered failed datasets)",
+                    "output_name": "output",
+                    "uuid": "b678e146-ec9e-4720-af34-fb113af880ae"
+                }
+            ]
         },
-        "29": {
+        "28": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_cluster/scanpy_find_cluster/1.6.0+galaxy3",
             "errors": null,
-            "id": 29,
+            "id": 28,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "output_h5ad"
                 },
                 "settings|resolution_file": {
@@ -1646,14 +1591,14 @@
                 }
             ],
             "position": {
-                "bottom": 486,
+                "bottom": 170.5,
                 "height": 312,
-                "left": 1862.5,
-                "right": 2062.5,
-                "top": 174,
+                "left": 1908.5,
+                "right": 2108.5,
+                "top": -141.5,
                 "width": 200,
-                "x": 1862.5,
-                "y": 174
+                "x": 1908.5,
+                "y": -141.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1691,24 +1636,24 @@
                 {
                     "label": null,
                     "output_name": "output_txt",
-                    "uuid": "96b68a17-f405-4fe5-929a-bc5abd95ee33"
+                    "uuid": "de0b6c35-bbc5-434c-8ff8-fc68f8679165"
                 }
             ]
         },
-        "30": {
+        "29": {
             "annotation": "",
-            "content_id": "__FILTER_FAILED_DATASETS__",
+            "content_id": "__BUILD_LIST__",
             "errors": null,
-            "id": 30,
+            "id": 29,
             "input_connections": {
-                "input": {
-                    "id": 26,
+                "datasets_0|input": {
+                    "id": 25,
                     "output_name": "output_h5ad"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Filter failed",
+            "name": "Build List",
             "outputs": [
                 {
                     "name": "output",
@@ -1716,37 +1661,37 @@
                 }
             ],
             "position": {
-                "bottom": 830,
+                "bottom": -179.5,
                 "height": 112,
-                "left": 2140.5,
-                "right": 2340.5,
-                "top": 718,
+                "left": 1908.5,
+                "right": 2108.5,
+                "top": -291.5,
                 "width": 200,
-                "x": 2140.5,
-                "y": 718
+                "x": 1908.5,
+                "y": -291.5
             },
-            "post_job_actions": {},
-            "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__BUILD_LIST__",
+            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "0a6202a1-c823-4859-ba81-269390c4dcf6",
-            "workflow_outputs": [
-                {
-                    "label": "input dataset(s) (filtered failed datasets)",
-                    "output_name": "output",
-                    "uuid": "d129f474-8c05-4d5e-8e8f-0a021c406ba0"
-                }
-            ]
+            "uuid": "7a39daea-90cf-4bb5-a911-bdde42cf7811",
+            "workflow_outputs": []
         },
-        "31": {
+        "30": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_run_umap/scanpy_run_umap/1.6.0+galaxy1",
             "errors": null,
-            "id": 31,
+            "id": 30,
             "input_connections": {
                 "input_obj_file": {
-                    "id": 27,
+                    "id": 26,
                     "output_name": "output_h5ad"
                 }
             },
@@ -1764,14 +1709,14 @@
                 }
             ],
             "position": {
-                "bottom": 1035,
+                "bottom": 719.5,
                 "height": 222,
-                "left": 1862.5,
-                "right": 2062.5,
-                "top": 813,
+                "left": 1908.5,
+                "right": 2108.5,
+                "top": 497.5,
                 "width": 200,
-                "x": 1862.5,
-                "y": 813
+                "x": 1908.5,
+                "y": 497.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1807,22 +1752,22 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "4b0b21b9-741d-4c89-a7da-189db65b890a"
+                    "uuid": "424a55b1-2538-4a47-9593-3efad6bcc769"
                 }
             ]
         },
-        "32": {
+        "31": {
             "annotation": "",
             "content_id": "__MERGE_COLLECTION__",
             "errors": null,
-            "id": 32,
+            "id": 31,
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 29,
+                    "id": 28,
                     "output_name": "output_h5ad"
                 },
                 "inputs_1|input": {
-                    "id": 28,
+                    "id": 29,
                     "output_name": "output"
                 }
             },
@@ -1836,14 +1781,14 @@
                 }
             ],
             "position": {
-                "bottom": 394,
+                "bottom": 78.5,
                 "height": 202,
-                "left": 2140.5,
-                "right": 2340.5,
-                "top": 192,
+                "left": 2186.5,
+                "right": 2386.5,
+                "top": -123.5,
                 "width": 200,
-                "x": 2140.5,
-                "y": 192
+                "x": 2186.5,
+                "y": -123.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1859,14 +1804,14 @@
             "uuid": "30d07b08-fe9d-4d21-8388-0795d35db7e1",
             "workflow_outputs": []
         },
-        "33": {
+        "32": {
             "annotation": "",
             "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 33,
+            "id": 32,
             "input_connections": {
                 "input": {
-                    "id": 31,
+                    "id": 30,
                     "output_name": "output_h5"
                 }
             },
@@ -1880,14 +1825,14 @@
                 }
             ],
             "position": {
-                "bottom": 980,
+                "bottom": 664.5,
                 "height": 112,
-                "left": 2140.5,
-                "right": 2340.5,
-                "top": 868,
+                "left": 2186.5,
+                "right": 2386.5,
+                "top": 552.5,
                 "width": 200,
-                "x": 2140.5,
-                "y": 868
+                "x": 2186.5,
+                "y": 552.5
             },
             "post_job_actions": {},
             "tool_id": "__FILTER_FAILED_DATASETS__",
@@ -1899,22 +1844,22 @@
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "a5f2e4e0-2681-4515-a522-ccea0b347507"
+                    "uuid": "78fabe4f-6990-4329-a1d9-1dd8b6eb60ef"
                 }
             ]
         },
-        "34": {
+        "33": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_find_markers/scanpy_find_markers/1.6.0+galaxy4",
             "errors": null,
-            "id": 34,
+            "id": 33,
             "input_connections": {
                 "groupby_file": {
                     "id": 14,
                     "output_name": "output"
                 },
                 "input_obj_file": {
-                    "id": 32,
+                    "id": 31,
                     "output_name": "output"
                 }
             },
@@ -1932,14 +1877,14 @@
                 }
             ],
             "position": {
-                "bottom": 516,
+                "bottom": 409.5,
                 "height": 292,
-                "left": 2418.5,
-                "right": 2618.5,
-                "top": 224,
+                "left": 2464.5,
+                "right": 2664.5,
+                "top": 117.5,
                 "width": 200,
-                "x": 2418.5,
-                "y": 224
+                "x": 2464.5,
+                "y": 117.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_h5ad": {
@@ -1970,22 +1915,22 @@
                 {
                     "label": null,
                     "output_name": "output_tsv",
-                    "uuid": "56482e95-e7e8-42fe-b9fd-6e3c64029bc8"
+                    "uuid": "55bcc812-4e9a-4fff-b6f1-6aa6e6ad3312"
                 }
             ]
         },
-        "35": {
+        "34": {
             "annotation": "",
             "content_id": "__MERGE_COLLECTION__",
             "errors": null,
-            "id": 35,
+            "id": 34,
             "input_connections": {
                 "inputs_0|input": {
-                    "id": 30,
+                    "id": 27,
                     "output_name": "output"
                 },
                 "inputs_1|input": {
-                    "id": 33,
+                    "id": 32,
                     "output_name": "output"
                 }
             },
@@ -1999,14 +1944,14 @@
                 }
             ],
             "position": {
-                "bottom": 988,
+                "bottom": 672.5,
                 "height": 202,
-                "left": 2418.5,
-                "right": 2618.5,
-                "top": 786,
+                "left": 2464.5,
+                "right": 2664.5,
+                "top": 470.5,
                 "width": 200,
-                "x": 2418.5,
-                "y": 786
+                "x": 2464.5,
+                "y": 470.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2027,14 +1972,14 @@
             "uuid": "02f93344-d954-4a14-a8de-5482ea7adbd0",
             "workflow_outputs": []
         },
-        "36": {
+        "35": {
             "annotation": "",
             "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 36,
+            "id": 35,
             "input_connections": {
                 "input": {
-                    "id": 34,
+                    "id": 33,
                     "output_name": "output_h5ad"
                 }
             },
@@ -2048,14 +1993,14 @@
                 }
             ],
             "position": {
-                "bottom": 436,
+                "bottom": 507.5,
                 "height": 132,
-                "left": 2696.5,
-                "right": 2896.5,
-                "top": 304,
+                "left": 2742.5,
+                "right": 2942.5,
+                "top": 375.5,
                 "width": 200,
-                "x": 2696.5,
-                "y": 304
+                "x": 2742.5,
+                "y": 375.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2076,18 +2021,18 @@
             "uuid": "ed346e6d-aadb-4dbf-a23a-86a1714aea5f",
             "workflow_outputs": []
         },
-        "37": {
+        "36": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/anndata_ops/anndata_ops/1.7.2+galaxy0",
             "errors": null,
-            "id": 37,
+            "id": 36,
             "input_connections": {
                 "copy_e|embedding_sources": {
-                    "id": 35,
+                    "id": 34,
                     "output_name": "output"
                 },
                 "copy_o|obs_sources": {
-                    "id": 36,
+                    "id": 35,
                     "output_name": "output"
                 },
                 "copy_r|r_source": {
@@ -2095,7 +2040,7 @@
                     "output_name": "output_h5ad"
                 },
                 "copy_u|uns_sources": {
-                    "id": 36,
+                    "id": 35,
                     "output_name": "output"
                 },
                 "copy_x|xlayers_0|x_source": {
@@ -2103,7 +2048,7 @@
                     "output_name": "output_h5ad"
                 },
                 "input_obj_file": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "output_h5ad"
                 }
             },
@@ -2117,14 +2062,14 @@
                 }
             ],
             "position": {
-                "bottom": 621,
+                "bottom": 822.5,
                 "height": 502,
-                "left": 2984.5,
-                "right": 3184.5,
-                "top": 119,
+                "left": 3030.5,
+                "right": 3230.5,
+                "top": 320.5,
                 "width": 200,
-                "x": 2984.5,
-                "y": 119
+                "x": 3030.5,
+                "y": 320.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -2150,12 +2095,12 @@
                 {
                     "label": null,
                     "output_name": "output_h5ad",
-                    "uuid": "1d37666e-774a-4121-8f09-277faf4c76fb"
+                    "uuid": "f42a9761-6841-4390-bd96-9065a51fa67a"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "0fc26658-8d36-48e9-9a70-f3ff98242c13",
-    "version": 11
+    "uuid": "0b208676-d14a-42ac-8d3a-d535dfc019ce",
+    "version": 13
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow.json
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow.json
@@ -13,32 +13,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "matrix"
+                    "name": "gtf"
                 }
             ],
-            "label": "matrix",
+            "label": "gtf",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 412.5,
+                "bottom": 285.5,
                 "height": 61,
-                "left": -623.5,
-                "right": -423.5,
-                "top": 351.5,
+                "left": 460,
+                "right": 660,
+                "top": 224.5,
                 "width": 200,
-                "x": -623.5,
-                "y": 351.5
+                "x": 460,
+                "y": 224.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
+            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "5bca189e-a1aa-46da-8a20-6f6c25212e34"
+                    "uuid": "709ef392-251d-4faa-8dce-e17a42f1a275"
                 }
             ]
         },
@@ -51,32 +51,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "cellmeta"
+                    "name": "genes"
                 }
             ],
-            "label": "cellmeta",
+            "label": "genes",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 511.5,
+                "bottom": 439.5,
                 "height": 61,
-                "left": -623.5,
-                "right": -423.5,
-                "top": 450.5,
+                "left": 738,
+                "right": 938,
+                "top": 378.5,
                 "width": 200,
-                "x": -623.5,
-                "y": 450.5
+                "x": 738,
+                "y": 378.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
+            "uuid": "79451756-8ed4-4600-a94b-3603b3b6d147",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "51456688-b340-47a4-8eda-7469dfc18cc0"
+                    "uuid": "6e5f9319-ba9d-486f-bda2-d971f6ad961a"
                 }
             ]
         },
@@ -89,32 +89,32 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "barcodes"
+                    "name": "matrix"
                 }
             ],
-            "label": "barcodes",
+            "label": "matrix",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 610.5,
+                "bottom": 422.5,
                 "height": 61,
-                "left": -623.5,
-                "right": -423.5,
-                "top": 549.5,
+                "left": 1294,
+                "right": 1494,
+                "top": 361.5,
                 "width": 200,
-                "x": -623.5,
-                "y": 549.5
+                "x": 1294,
+                "y": 361.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
+            "uuid": "0593d085-1073-49e4-93c9-1ca8151e2593",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "e44cb7cf-0e7a-4fd8-a551-2e7fdd1c9968"
+                    "uuid": "af823244-0dbe-4f10-8f74-4ced8a2dc1b7"
                 }
             ]
         },
@@ -127,40 +127,78 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "genes"
+                    "name": "cellmeta"
                 }
             ],
-            "label": "genes",
+            "label": "cellmeta",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 429.5,
+                "bottom": 521.5,
                 "height": 61,
-                "left": -1179.5,
-                "right": -979.5,
-                "top": 368.5,
+                "left": 1294,
+                "right": 1494,
+                "top": 460.5,
                 "width": 200,
-                "x": -1179.5,
-                "y": 368.5
+                "x": 1294,
+                "y": 460.5
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "79451756-8ed4-4600-a94b-3603b3b6d147",
+            "uuid": "6888e349-0ce3-4833-a93d-58297a834969",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "1d8f3d25-f4a0-4cc3-ad7a-6f24d989eb45"
+                    "uuid": "44576d23-e925-4ea8-a493-b4f11844befe"
                 }
             ]
         },
         "4": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "content_id": null,
             "errors": null,
             "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "barcodes"
+                }
+            ],
+            "label": "barcodes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 620.5,
+                "height": 61,
+                "left": 1294,
+                "right": 1494,
+                "top": 559.5,
+                "width": 200,
+                "x": 1294,
+                "y": 559.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "2f95ff2d-cc02-4a39-a558-4ad5447a8b83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "64a0dbb9-18d4-4384-b452-f437f5c1032a"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy1",
+            "errors": null,
+            "id": 5,
             "input_connections": {},
             "inputs": [],
             "label": "perplexity",
@@ -172,14 +210,14 @@
                 }
             ],
             "position": {
-                "bottom": 418.5,
+                "bottom": 428.5,
                 "height": 81,
-                "left": 1332.5,
-                "right": 1532.5,
-                "top": 337.5,
+                "left": 3250,
+                "right": 3450,
+                "top": 347.5,
                 "width": 200,
-                "x": 1332.5,
-                "y": 337.5
+                "x": 3250,
+                "y": 347.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -206,11 +244,11 @@
             "uuid": "00700721-8faf-4f86-9d80-2daf4bebffeb",
             "workflow_outputs": []
         },
-        "5": {
+        "6": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_parameter_iterator/scanpy_parameter_iterator/0.0.1+galaxy2",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {},
             "inputs": [],
             "label": "n_neighbors",
@@ -222,16 +260,21 @@
                 }
             ],
             "position": {
-                "bottom": 655.5,
+                "bottom": 666.5,
                 "height": 81,
-                "left": 1332.5,
-                "right": 1532.5,
-                "top": 574.5,
+                "left": 3250,
+                "right": 3450,
+                "top": 585.5,
                 "width": 200,
-                "x": 1332.5,
-                "y": 574.5
+                "x": 3250,
+                "y": 585.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "parameter_iteration"
+                },
                 "HideDatasetActionparameter_iteration": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -248,46 +291,8 @@
             "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"3, 5, 10, 15, 20, 25, 30, 50, 100\"}, \"parameter_name\": \"n_neighbors\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.1+galaxy2",
             "type": "tool",
-            "uuid": "5e22d4cd-71d6-4a91-b326-508494138b82",
+            "uuid": "ca0708bd-865d-48dc-ad22-f81a8d0c2e01",
             "workflow_outputs": []
-        },
-        "6": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 6,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "gtf"
-                }
-            ],
-            "label": "gtf",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "bottom": 275.5,
-                "height": 61,
-                "left": -1457.5,
-                "right": -1257.5,
-                "top": 214.5,
-                "width": 200,
-                "x": -1457.5,
-                "y": 214.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "68401568-bc33-4d11-bee6-65c3abd6d870",
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "9c89e3b1-1281-4187-b0a9-e346cc300f22"
-                }
-            ]
         },
         "7": {
             "annotation": "",
@@ -305,14 +310,14 @@
                 }
             ],
             "position": {
-                "bottom": 54.5,
+                "bottom": 65.5,
                 "height": 81,
-                "left": 1620.5,
-                "right": 1820.5,
-                "top": -26.5,
+                "left": 3538,
+                "right": 3738,
+                "top": -15.5,
                 "width": 200,
-                "x": 1620.5,
-                "y": -26.5
+                "x": 3538,
+                "y": -15.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionparameter_iteration": {
@@ -355,16 +360,21 @@
                 }
             ],
             "position": {
-                "bottom": 439.5,
+                "bottom": 449.5,
                 "height": 81,
-                "left": 1908.5,
-                "right": 2108.5,
-                "top": 358.5,
+                "left": 3826,
+                "right": 4026,
+                "top": 368.5,
                 "width": 200,
-                "x": 1908.5,
-                "y": 358.5
+                "x": 3826,
+                "y": 368.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionparameter_iteration": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "parameter_iteration"
+                },
                 "HideDatasetActionparameter_iteration": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -381,7 +391,7 @@
             "tool_state": "{\"input_type\": {\"parameter_values\": \"list_comma_separated_values\", \"__current_case__\": 0, \"input_values\": \"CELL_TYPE_FIELD\"}, \"parameter_name\": \"meta\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.1+galaxy3",
             "type": "tool",
-            "uuid": "7942bdd0-8738-42ff-9251-10886d5125a6",
+            "uuid": "b0153814-f701-4f0a-ab1f-cee9e434e915",
             "workflow_outputs": []
         },
         "9": {
@@ -391,11 +401,16 @@
             "id": 9,
             "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool GTF2GeneList",
+                    "name": "gtf_input"
+                }
+            ],
             "label": null,
             "name": "GTF2GeneList",
             "outputs": [
@@ -405,14 +420,14 @@
                 }
             ],
             "position": {
-                "bottom": 311.5,
+                "bottom": 609.5,
                 "height": 132,
-                "left": -335.5,
-                "right": -135.5,
-                "top": 179.5,
+                "left": 738,
+                "right": 938,
+                "top": 477.5,
                 "width": 200,
-                "x": -335.5,
-                "y": 179.5
+                "x": 738,
+                "y": 477.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -420,6 +435,11 @@
                         "newtype": "tabular"
                     },
                     "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
                     "output_name": "feature_annotation"
                 },
                 "HideDatasetActionfeature_annotation": {
@@ -435,10 +455,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id,gene_name\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "a341aa66-f857-49b2-9614-a7231237d5ce",
+            "uuid": "a1ebb947-640a-4c27-a2a7-715170b05a4c",
             "workflow_outputs": []
         },
         "10": {
@@ -448,11 +468,16 @@
             "id": 10,
             "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool GTF2GeneList",
+                    "name": "gtf_input"
+                }
+            ],
             "label": null,
             "name": "GTF2GeneList",
             "outputs": [
@@ -462,14 +487,14 @@
                 }
             ],
             "position": {
-                "bottom": 397.5,
+                "bottom": 408.5,
                 "height": 132,
-                "left": -901.5,
-                "right": -701.5,
-                "top": 265.5,
+                "left": 1016,
+                "right": 1216,
+                "top": 276.5,
                 "width": 200,
-                "x": -901.5,
-                "y": 265.5
+                "x": 1016,
+                "y": 276.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -477,6 +502,11 @@
                         "newtype": "tabular"
                     },
                     "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
                     "output_name": "feature_annotation"
                 },
                 "HideDatasetActionfeature_annotation": {
@@ -492,10 +522,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"true\", \"__current_case__\": 0, \"mito_chr\": \"mt,mitochondrion_genome,mito,m,chrM,chrMt\", \"mito_biotypes\": \"mt_trna,mt_rrna,mt_trna_pseudogene\"}, \"noheader\": \"false\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "5c0d8c50-7891-4dc6-826f-0e5a6d3117bb",
+            "uuid": "3e5764bd-c583-47a8-9e8f-fd5f2b609705",
             "workflow_outputs": []
         },
         "11": {
@@ -505,11 +535,16 @@
             "id": 11,
             "input_connections": {
                 "gtf_input": {
-                    "id": 6,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool GTF2GeneList",
+                    "name": "gtf_input"
+                }
+            ],
             "label": null,
             "name": "GTF2GeneList",
             "outputs": [
@@ -519,14 +554,14 @@
                 }
             ],
             "position": {
-                "bottom": 599.5,
+                "bottom": 321.5,
                 "height": 132,
-                "left": -1179.5,
-                "right": -979.5,
-                "top": 467.5,
+                "left": 1582,
+                "right": 1782,
+                "top": 189.5,
                 "width": 200,
-                "x": -1179.5,
-                "y": 467.5
+                "x": 1582,
+                "y": 189.5
             },
             "post_job_actions": {
                 "ChangeDatatypeActionfeature_annotation": {
@@ -534,6 +569,11 @@
                         "newtype": "tabular"
                     },
                     "action_type": "ChangeDatatypeAction",
+                    "output_name": "feature_annotation"
+                },
+                "DeleteIntermediatesActionfeature_annotation": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
                     "output_name": "feature_annotation"
                 },
                 "HideDatasetActionfeature_annotation": {
@@ -549,10 +589,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id,gene_name\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"ConnectedValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"cdnas\": {\"filter_cdnas\": \"false\", \"__current_case__\": 1}, \"feature_type\": \"gene\", \"fields\": \"gene_id\", \"first_field\": \"gene_id\", \"gtf_input\": {\"__class__\": \"RuntimeValue\"}, \"mito\": {\"mark_mito\": \"false\", \"__current_case__\": 1}, \"noheader\": \"true\", \"version_transcripts\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.42.1+galaxy4",
             "type": "tool",
-            "uuid": "d14f7483-6bbb-4262-a1b1-2d8bb09457d7",
+            "uuid": "588f7d28-70ac-4ea7-b8ce-1430f334f9f2",
             "workflow_outputs": []
         },
         "12": {
@@ -566,8 +606,13 @@
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [],
-            "label": "clusering_slotnames",
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace Text",
+                    "name": "infile"
+                }
+            ],
+            "label": "clustering_slotnames",
             "name": "Replace Text",
             "outputs": [
                 {
@@ -576,16 +621,21 @@
                 }
             ],
             "position": {
-                "bottom": 320.5,
+                "bottom": 330.5,
                 "height": 112,
-                "left": 1908.5,
-                "right": 2108.5,
-                "top": 208.5,
+                "left": 3826,
+                "right": 4026,
+                "top": 218.5,
                 "width": 200,
-                "x": 1908.5,
-                "y": 208.5
+                "x": 3826,
+                "y": 218.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "outfile"
+                },
                 "HideDatasetActionoutfile": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -606,10 +656,10 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"infile\": {\"__class__\": \"RuntimeValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"(.*)\", \"replace_pattern\": \"louvain_resolution_\\\\1\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
-            "uuid": "2c325236-8140-4904-9a72-5a037f7484b8",
+            "uuid": "8f5eeae2-a260-4a87-8049-6772d5412129",
             "workflow_outputs": []
         },
         "13": {
@@ -619,15 +669,24 @@
             "id": 13,
             "input_connections": {
                 "input1": {
-                    "id": 3,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "input2": {
-                    "id": 11,
+                    "id": 9,
                     "output_name": "feature_annotation"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Join two Datasets",
+                    "name": "input1"
+                },
+                {
+                    "description": "runtime parameter for tool Join two Datasets",
+                    "name": "input2"
+                }
+            ],
             "label": null,
             "name": "Join two Datasets",
             "outputs": [
@@ -637,26 +696,32 @@
                 }
             ],
             "position": {
-                "bottom": 577.5,
+                "bottom": 587.5,
                 "height": 142,
-                "left": -901.5,
-                "right": -701.5,
-                "top": 435.5,
+                "left": 1016,
+                "right": 1216,
+                "top": 445.5,
                 "width": 200,
-                "x": -901.5,
-                "y": 435.5
+                "x": 1016,
+                "y": 445.5
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "DeleteIntermediatesActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "out_file1"
+                }
+            },
             "tool_id": "join1",
-            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"fill_empty_columns\": {\"fill_empty_columns_switch\": \"no_fill\", \"__current_case__\": 0}, \"header\": \"\", \"input1\": {\"__class__\": \"RuntimeValue\"}, \"input2\": {\"__class__\": \"RuntimeValue\"}, \"partial\": \"-p\", \"unmatched\": \"-u\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.3",
             "type": "tool",
-            "uuid": "9ee16d67-bbd0-4b40-ba61-dcc6b12c75d2",
+            "uuid": "c58555b8-032b-482d-9ef4-966421ef8f07",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "ea000a47-9e5d-449c-a927-7a46efc02a3c"
+                    "uuid": "f8cc259c-eaba-418b-a63a-732c7913f72b"
                 }
             ]
         },
@@ -685,16 +750,21 @@
                 }
             ],
             "position": {
-                "bottom": 364.5,
+                "bottom": 374.5,
                 "height": 202,
-                "left": 2186.5,
-                "right": 2386.5,
-                "top": 162.5,
+                "left": 4104,
+                "right": 4304,
+                "top": 172.5,
                 "width": 200,
-                "x": 2186.5,
-                "y": 162.5
+                "x": 4104,
+                "y": 172.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -702,10 +772,10 @@
                 }
             },
             "tool_id": "__MERGE_COLLECTION__",
-            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "ba78a440-74fd-4fe1-972e-69004ee2186f",
+            "uuid": "9eff549e-9dfc-4573-9339-68f539ea8fa1",
             "workflow_outputs": []
         },
         "15": {
@@ -719,7 +789,12 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Cut",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Cut",
             "outputs": [
@@ -729,26 +804,32 @@
                 }
             ],
             "position": {
-                "bottom": 740.5,
+                "bottom": 750.5,
                 "height": 92,
-                "left": -623.5,
-                "right": -423.5,
-                "top": 648.5,
+                "left": 1294,
+                "right": 1494,
+                "top": 658.5,
                 "width": 200,
-                "x": -623.5,
-                "y": 648.5
+                "x": 1294,
+                "y": 658.5
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "DeleteIntermediatesActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "out_file1"
+                }
+            },
             "tool_id": "Cut1",
-            "tool_state": "{\"columnList\": \"c1,c4\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"columnList\": \"c1,c4\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "e7ddd27d-1f26-4ed3-ad82-f293e4006c59",
+            "uuid": "4e1efb96-8d39-4e89-8a77-a2a6d5ec7578",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "out_file1",
-                    "uuid": "9d57ba04-3d54-4d84-8789-2389c506fc91"
+                    "uuid": "d6cfb911-54be-4ecc-a6ac-64b5a862d4b5"
                 }
             ]
         },
@@ -759,11 +840,11 @@
             "id": 16,
             "input_connections": {
                 "barcodes": {
-                    "id": 2,
+                    "id": 4,
                     "output_name": "output"
                 },
                 "cell_meta": {
-                    "id": 1,
+                    "id": 3,
                     "output_name": "output"
                 },
                 "gene_meta": {
@@ -775,11 +856,32 @@
                     "output_name": "out_file1"
                 },
                 "matrix": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x",
+                    "name": "barcodes"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x",
+                    "name": "cell_meta"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x",
+                    "name": "gene_meta"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x",
+                    "name": "genes"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy Read10x",
+                    "name": "matrix"
+                }
+            ],
             "label": null,
             "name": "Scanpy Read10x",
             "outputs": [
@@ -789,32 +891,25 @@
                 }
             ],
             "position": {
-                "bottom": 641.5,
+                "bottom": 651.5,
                 "height": 292,
-                "left": -335.5,
-                "right": -135.5,
-                "top": 349.5,
+                "left": 1582,
+                "right": 1782,
+                "top": 359.5,
                 "width": 200,
-                "x": -335.5,
-                "y": 349.5
+                "x": 1582,
+                "y": 359.5
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
+                "DeleteIntermediatesActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
+                    "output_name": "output_h5ad"
                 },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
                     "output_name": "output_h5ad"
-                },
-                "RenameDatasetActionoutput_h5": {
-                    "action_arguments": {
-                        "newname": "raw.h5"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output_h5"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_read_10x/scanpy_read_10x/1.6.0+galaxy0",
@@ -824,10 +919,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"barcodes\": {\"__class__\": \"ConnectedValue\"}, \"cell_meta\": {\"__class__\": \"ConnectedValue\"}, \"gene_meta\": {\"__class__\": \"ConnectedValue\"}, \"genes\": {\"__class__\": \"ConnectedValue\"}, \"matrix\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"var_names\": \"gene_ids\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"barcodes\": {\"__class__\": \"RuntimeValue\"}, \"cell_meta\": {\"__class__\": \"RuntimeValue\"}, \"gene_meta\": {\"__class__\": \"RuntimeValue\"}, \"genes\": {\"__class__\": \"RuntimeValue\"}, \"matrix\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"var_names\": \"gene_ids\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "a79f73e7-41c3-49c0-b893-6afac53be3fe",
+            "uuid": "1af61f15-d508-41d7-9123-b08b66458ad8",
             "workflow_outputs": []
         },
         "17": {
@@ -841,7 +936,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FilterCells",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "filter_cells",
             "name": "Scanpy FilterCells",
             "outputs": [
@@ -863,20 +963,20 @@
                 }
             ],
             "position": {
-                "bottom": 730.5,
+                "bottom": 740.5,
                 "height": 362,
-                "left": -57.5,
-                "right": 142.5,
-                "top": 368.5,
+                "left": 1860,
+                "right": 2060,
+                "top": 378.5,
                 "width": 200,
-                "x": -57.5,
-                "y": 368.5
+                "x": 1860,
+                "y": 378.5
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
+                "DeleteIntermediatesActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
+                    "output_name": "output_h5ad"
                 },
                 "HideDatasetActionbarcodes_10x": {
                     "action_arguments": {},
@@ -906,10 +1006,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"gene_name\": \"gene_symbols\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_genes\", \"min\": \"400.0\", \"max\": \"1000000000.0\"}, {\"__index__\": 1, \"name\": \"n_counts\", \"min\": \"0.0\", \"max\": \"1000000000.0\"}], \"subsets\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"gene_name\": \"gene_symbols\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_genes\", \"min\": \"400.0\", \"max\": \"1000000000.0\"}, {\"__index__\": 1, \"name\": \"n_counts\", \"min\": \"0.0\", \"max\": \"1000000000.0\"}], \"subsets\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "da752cb4-6258-4331-b8d4-328a85796f2e",
+            "uuid": "3d899480-ea8f-4450-baa1-518b1f1c222a",
             "workflow_outputs": []
         },
         "18": {
@@ -923,11 +1023,16 @@
                     "output_name": "output_h5ad"
                 },
                 "subsets_0|subset": {
-                    "id": 9,
+                    "id": 11,
                     "output_name": "feature_annotation"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FilterGenes",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "filter_genes",
             "name": "Scanpy FilterGenes",
             "outputs": [
@@ -949,20 +1054,20 @@
                 }
             ],
             "position": {
-                "bottom": 611.5,
+                "bottom": 621.5,
                 "height": 432,
-                "left": 220.5,
-                "right": 420.5,
-                "top": 179.5,
+                "left": 2138,
+                "right": 2338,
+                "top": 189.5,
                 "width": 200,
-                "x": 220.5,
-                "y": 179.5
+                "x": 2138,
+                "y": 189.5
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
+                "DeleteIntermediatesActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
+                    "output_name": "output_h5ad"
                 },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
@@ -998,25 +1103,25 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_cells\", \"min\": \"3.0\", \"max\": \"1000000000.0\"}], \"subsets\": [{\"__index__\": 0, \"name\": \"index\", \"subset\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"categories\": [], \"export_mtx\": \"true\", \"force_recalc\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"parameters\": [{\"__index__\": 0, \"name\": \"n_cells\", \"min\": \"3.0\", \"max\": \"1000000000.0\"}], \"subsets\": [{\"__index__\": 0, \"name\": \"index\", \"subset\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "7983f312-72ed-44dc-88bb-85fb66265828",
+            "uuid": "1c7ea27f-d533-4315-8ee1-49d0de3e66de",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "genes_10x",
-                    "uuid": "78442981-8284-4ad3-bdf8-945feb54a663"
-                },
-                {
-                    "label": null,
-                    "output_name": "matrix_10x",
-                    "uuid": "54b40224-f965-44ab-928b-7b65791511ae"
+                    "uuid": "cb555fd4-046e-4b90-839f-164de0e58dfd"
                 },
                 {
                     "label": null,
                     "output_name": "barcodes_10x",
-                    "uuid": "7c04db19-8a08-4b94-91fd-389eb14d378e"
+                    "uuid": "2de1b144-155b-461e-be0b-6deb34ac1d21"
+                },
+                {
+                    "label": null,
+                    "output_name": "matrix_10x",
+                    "uuid": "e9655a0d-e7c8-4456-9046-ef65e13744bc"
                 }
             ]
         },
@@ -1031,7 +1136,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy NormaliseData",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "normalise_data_internal",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1041,16 +1151,21 @@
                 }
             ],
             "position": {
-                "bottom": 299.5,
+                "bottom": 309.5,
                 "height": 192,
-                "left": 498.5,
-                "right": 698.5,
-                "top": 107.5,
+                "left": 2416,
+                "right": 2616,
+                "top": 117.5,
                 "width": 200,
-                "x": 498.5,
-                "y": 107.5
+                "x": 2416,
+                "y": 117.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1059,15 +1174,15 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "28ab1cdd0cf5",
+                "changeset_revision": "3a4564b9d685",
                 "name": "scanpy_normalise_data",
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"false\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"true\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "115fd89d-67e2-4256-91df-a056a03c16a0",
+            "uuid": "6c7c53cb-ac61-4c51-b09e-7491256e078a",
             "workflow_outputs": []
         },
         "20": {
@@ -1081,7 +1196,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy NormaliseData",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "normalise_data",
             "name": "Scanpy NormaliseData",
             "outputs": [
@@ -1103,16 +1223,21 @@
                 }
             ],
             "position": {
-                "bottom": 719.5,
+                "bottom": 729.5,
                 "height": 382,
-                "left": 498.5,
-                "right": 698.5,
-                "top": 337.5,
+                "left": 2416,
+                "right": 2616,
+                "top": 347.5,
                 "width": 200,
-                "x": 498.5,
-                "y": 337.5
+                "x": 2416,
+                "y": 347.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1142,30 +1267,30 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/ebi-gxa/scanpy_normalise_data/scanpy_normalise_data/1.7.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "28ab1cdd0cf5",
+                "changeset_revision": "3a4564b9d685",
                 "name": "scanpy_normalise_data",
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"export_mtx\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"save_layer\": \"\", \"save_raw\": \"false\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"scale_factor\": \"1000000.0\", \"log_transform\": \"false\", \"exclude\": {\"exclude_highly_expressed\": \"false\", \"__current_case__\": 1}, \"layers\": \"\", \"layer_norm\": \"\", \"key_added\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.7.2+galaxy0",
             "type": "tool",
-            "uuid": "6ae16265-70c0-42e1-92f0-8a62dfef9dc8",
+            "uuid": "51574e14-2149-4112-8185-75385c4af358",
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "genes_10x",
-                    "uuid": "2eae1269-5b75-4296-9b48-a4706deebe81"
+                    "output_name": "barcodes_10x",
+                    "uuid": "abf47064-5e0f-4bd6-8f78-ee92d8315949"
                 },
                 {
                     "label": null,
                     "output_name": "matrix_10x",
-                    "uuid": "1bbdb614-62ca-47a8-9125-bdfb58763e57"
+                    "uuid": "958aec69-223c-4ddf-b861-b894756c2837"
                 },
                 {
                     "label": null,
-                    "output_name": "barcodes_10x",
-                    "uuid": "1c19bea1-f864-4e97-bfaf-b931b736609c"
+                    "output_name": "genes_10x",
+                    "uuid": "0e347d03-6fe9-4f93-857a-d1ee7c2900ba"
                 }
             ]
         },
@@ -1180,7 +1305,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindVariableGenes",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "find_variable_genes",
             "name": "Scanpy FindVariableGenes",
             "outputs": [
@@ -1190,20 +1320,20 @@
                 }
             ],
             "position": {
-                "bottom": 299.5,
+                "bottom": 309.5,
                 "height": 192,
-                "left": 776.5,
-                "right": 976.5,
-                "top": 107.5,
+                "left": 2694,
+                "right": 2894,
+                "top": 117.5,
                 "width": 200,
-                "x": 776.5,
-                "y": 107.5
+                "x": 2694,
+                "y": 117.5
             },
             "post_job_actions": {
-                "DeleteIntermediatesActionoutput_h5": {
+                "DeleteIntermediatesActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "DeleteIntermediatesAction",
-                    "output_name": "output_h5"
+                    "output_name": "output_h5ad"
                 },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
@@ -1218,10 +1348,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"batch_key\": \"\", \"filter\": \"false\", \"flavor\": \"seurat\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"max_disp\": \"50.0\", \"max_mean\": \"1000000000.0\", \"min_disp\": \"0.5\", \"min_mean\": \"0.0125\", \"n_bin\": \"20\", \"n_top_gene\": \"\", \"output_format\": \"anndata_h5ad\", \"span\": \"0.3\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"batch_key\": \"\", \"filter\": \"false\", \"flavor\": \"seurat\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"max_disp\": \"50.0\", \"max_mean\": \"1000000000.0\", \"min_disp\": \"0.5\", \"min_mean\": \"0.0125\", \"n_bin\": \"20\", \"n_top_gene\": \"\", \"output_format\": \"anndata_h5ad\", \"span\": \"0.3\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy0",
             "type": "tool",
-            "uuid": "acd1272b-3c87-49c5-b100-e12a832171cb",
+            "uuid": "e34f75bb-b3b3-4177-983e-dae86d835f01",
             "workflow_outputs": []
         },
         "22": {
@@ -1235,7 +1365,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy RunPCA",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "run_pca",
             "name": "Scanpy RunPCA",
             "outputs": [
@@ -1245,16 +1380,21 @@
                 }
             ],
             "position": {
-                "bottom": 279.5,
+                "bottom": 289.5,
                 "height": 152,
-                "left": 1054.5,
-                "right": 1254.5,
-                "top": 127.5,
+                "left": 2972,
+                "right": 3172,
+                "top": 137.5,
                 "width": 200,
-                "x": 1054.5,
-                "y": 127.5
+                "x": 2972,
+                "y": 137.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1268,10 +1408,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"extra_outputs\": null, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"n_pcs\": \"\", \"output_format\": \"anndata_h5ad\", \"run_mode\": {\"chunked\": \"false\", \"__current_case__\": 1, \"zero_center\": \"false\", \"svd_solver\": \"arpack\", \"random_seed\": \"1234\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"extra_outputs\": null, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"n_pcs\": \"\", \"output_format\": \"anndata_h5ad\", \"run_mode\": {\"chunked\": \"false\", \"__current_case__\": 1, \"zero_center\": \"false\", \"svd_solver\": \"arpack\", \"random_seed\": \"1234\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
-            "uuid": "725b1084-4ac3-4305-b1c9-31c55508b7da",
+            "uuid": "96cc02ec-f20b-4ec1-8642-2d3c9df3f274",
             "workflow_outputs": []
         },
         "23": {
@@ -1285,7 +1425,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy Harmony",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "harmony_batch",
             "name": "Scanpy Harmony",
             "outputs": [
@@ -1295,16 +1440,21 @@
                 }
             ],
             "position": {
-                "bottom": 299.5,
+                "bottom": 309.5,
                 "height": 192,
-                "left": 1332.5,
-                "right": 1532.5,
-                "top": 107.5,
+                "left": 3250,
+                "right": 3450,
+                "top": 117.5,
                 "width": 200,
-                "x": 1332.5,
-                "y": 107.5
+                "x": 3250,
+                "y": 117.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1318,10 +1468,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adjusted_basis\": \"X_pca\", \"basis\": \"X_pca\", \"batch_key\": \"BATCH_FIELD\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"true\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adjusted_basis\": \"X_pca\", \"basis\": \"X_pca\", \"batch_key\": \"BATCH_FIELD\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"true\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy1",
             "type": "tool",
-            "uuid": "e2ffe318-8ec1-4bce-aae9-24117b30ac40",
+            "uuid": "ff1608fa-d723-4578-87d1-b6bba0c3aece",
             "workflow_outputs": []
         },
         "24": {
@@ -1335,11 +1485,20 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|perplexity_file": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy RunTSNE",
+                    "name": "input_obj_file"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy RunTSNE",
+                    "name": "settings"
+                }
+            ],
             "label": "run_tsne",
             "name": "Scanpy RunTSNE",
             "outputs": [
@@ -1353,16 +1512,21 @@
                 }
             ],
             "position": {
-                "bottom": 399.5,
+                "bottom": 409.5,
                 "height": 292,
-                "left": 1620.5,
-                "right": 1820.5,
-                "top": 107.5,
+                "left": 3538,
+                "right": 3738,
+                "top": 117.5,
                 "width": 200,
-                "x": 1620.5,
-                "y": 107.5
+                "x": 3538,
+                "y": 117.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1390,15 +1554,15 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"perplexity_PERPLEXITY\", \"perplexity\": \"30.0\", \"perplexity_file\": {\"__class__\": \"ConnectedValue\"}, \"early_exaggeration\": \"12.0\", \"learning_rate\": \"400.0\", \"fast_tsne\": \"false\", \"n_job\": \"\", \"n_pc\": \"\", \"random_seed\": \"1234\"}, \"use_rep\": \"auto\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"embeddings\": \"true\", \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"perplexity_PERPLEXITY\", \"perplexity\": \"30.0\", \"perplexity_file\": {\"__class__\": \"RuntimeValue\"}, \"early_exaggeration\": \"12.0\", \"learning_rate\": \"400.0\", \"fast_tsne\": \"false\", \"n_job\": \"\", \"n_pc\": \"\", \"random_seed\": \"1234\"}, \"use_rep\": \"auto\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy2",
             "type": "tool",
-            "uuid": "11d2deeb-54e6-470a-8831-ba3f51209c19",
+            "uuid": "5a8ce1c2-d259-4b85-b34b-9bde3fa1af6d",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "e686c16c-82c4-4930-9dca-3ea921c98c19"
+                    "uuid": "e89bf8bf-e3c3-45aa-8c4b-5d129ab5baba"
                 }
             ]
         },
@@ -1416,6 +1580,10 @@
             "inputs": [
                 {
                     "description": "runtime parameter for tool Scanpy ComputeGraph",
+                    "name": "input_obj_file"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph",
                     "name": "settings"
                 }
             ],
@@ -1428,16 +1596,21 @@
                 }
             ],
             "position": {
-                "bottom": -114.5,
+                "bottom": -104.5,
                 "height": 242,
-                "left": 1620.5,
-                "right": 1820.5,
-                "top": -356.5,
+                "left": 3538,
+                "right": 3738,
+                "top": -346.5,
                 "width": 200,
-                "x": 1620.5,
-                "y": -356.5
+                "x": 3538,
+                "y": -346.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1451,10 +1624,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "b3ccf81f-9897-4fa1-ac29-f8152d608c0e",
+            "uuid": "a3b89f7b-c3b4-42fc-9943-22d2939518df",
             "workflow_outputs": []
         },
         "26": {
@@ -1468,11 +1641,20 @@
                     "output_name": "output_h5ad"
                 },
                 "settings|n_neighbors_file": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph",
+                    "name": "input_obj_file"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy ComputeGraph",
+                    "name": "settings"
+                }
+            ],
             "label": "neighbours for umap",
             "name": "Scanpy ComputeGraph",
             "outputs": [
@@ -1482,16 +1664,21 @@
                 }
             ],
             "position": {
-                "bottom": 699.5,
+                "bottom": 709.5,
                 "height": 262,
-                "left": 1620.5,
-                "right": 1820.5,
-                "top": 437.5,
+                "left": 3538,
+                "right": 3738,
+                "top": 447.5,
                 "width": 200,
-                "x": 1620.5,
-                "y": 437.5
+                "x": 3538,
+                "y": 447.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1512,10 +1699,10 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"ConnectedValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"neighbors_n_neighbors_N_NEIGHBORS\", \"n_neighbors\": \"15\", \"n_neighbors_file\": {\"__class__\": \"RuntimeValue\"}, \"use_rep\": \"X_pca\", \"n_pcs\": \"50\", \"knn\": \"true\", \"method\": \"umap\", \"metric\": \"euclidean\", \"random_seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "ec037e7b-8aca-4266-a267-0ef3ef5ac7d8",
+            "uuid": "9dd6efe7-ab3e-4027-9b73-55025387f9b0",
             "workflow_outputs": []
         },
         "27": {
@@ -1529,7 +1716,12 @@
                     "output_name": "output_h5ad"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter failed",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Filter failed",
             "outputs": [
@@ -1539,26 +1731,32 @@
                 }
             ],
             "position": {
-                "bottom": 514.5,
+                "bottom": 524.5,
                 "height": 112,
-                "left": 2186.5,
-                "right": 2386.5,
-                "top": 402.5,
+                "left": 4104,
+                "right": 4304,
+                "top": 412.5,
                 "width": 200,
-                "x": 2186.5,
-                "y": 402.5
+                "x": 4104,
+                "y": 412.5
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                }
+            },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "0a6202a1-c823-4859-ba81-269390c4dcf6",
+            "uuid": "92c08e50-114f-4a3a-95b9-4a4ec20fff5d",
             "workflow_outputs": [
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "b678e146-ec9e-4720-af34-fb113af880ae"
+                    "uuid": "cbe1e012-9180-4a56-b9ed-648c85d7c980"
                 }
             ]
         },
@@ -1577,7 +1775,16 @@
                     "output_name": "parameter_iteration"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindCluster",
+                    "name": "input_obj_file"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy FindCluster",
+                    "name": "settings"
+                }
+            ],
             "label": "find_clusters",
             "name": "Scanpy FindCluster",
             "outputs": [
@@ -1591,16 +1798,21 @@
                 }
             ],
             "position": {
-                "bottom": 170.5,
+                "bottom": 180.5,
                 "height": 312,
-                "left": 1908.5,
-                "right": 2108.5,
-                "top": -141.5,
+                "left": 3826,
+                "right": 4026,
+                "top": -131.5,
                 "width": 200,
-                "x": 1908.5,
-                "y": -141.5
+                "x": 3826,
+                "y": -131.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1628,15 +1840,15 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"louvain\", \"output_cluster\": \"true\", \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"neighbors_key\": \"neighbors\", \"layer\": \"\", \"key_added\": \"METHOD_resolution_RESOLUTION\", \"resolution\": \"1.0\", \"resolution_file\": {\"__class__\": \"ConnectedValue\"}, \"restrict_to\": \"\", \"use_weights\": \"false\", \"random_seed\": \"1234\", \"directed\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"method\": \"louvain\", \"output_cluster\": \"true\", \"output_format\": \"anndata_h5ad\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"neighbors_key\": \"neighbors\", \"layer\": \"\", \"key_added\": \"METHOD_resolution_RESOLUTION\", \"resolution\": \"1.0\", \"resolution_file\": {\"__class__\": \"RuntimeValue\"}, \"restrict_to\": \"\", \"use_weights\": \"false\", \"random_seed\": \"1234\", \"directed\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy3",
             "type": "tool",
-            "uuid": "cbde22a5-8040-4f80-98a9-873ff646bf67",
+            "uuid": "3bdeb84a-d8ee-4319-a99f-2f2fa6e0d275",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_txt",
-                    "uuid": "de0b6c35-bbc5-434c-8ff8-fc68f8679165"
+                    "uuid": "4169db18-ac84-4913-8c3f-47b7c8a17bf2"
                 }
             ]
         },
@@ -1661,16 +1873,21 @@
                 }
             ],
             "position": {
-                "bottom": -179.5,
+                "bottom": -169.5,
                 "height": 112,
-                "left": 1908.5,
-                "right": 2108.5,
-                "top": -291.5,
+                "left": 3826,
+                "right": 4026,
+                "top": -281.5,
                 "width": 200,
-                "x": 1908.5,
-                "y": -291.5
+                "x": 3826,
+                "y": -281.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1678,10 +1895,10 @@
                 }
             },
             "tool_id": "__BUILD_LIST__",
-            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"datasets\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "7a39daea-90cf-4bb5-a911-bdde42cf7811",
+            "uuid": "4342456b-ed0a-45e1-b9d7-1cb1effd0cab",
             "workflow_outputs": []
         },
         "30": {
@@ -1709,14 +1926,14 @@
                 }
             ],
             "position": {
-                "bottom": 719.5,
+                "bottom": 729.5,
                 "height": 222,
-                "left": 1908.5,
-                "right": 2108.5,
-                "top": 497.5,
+                "left": 3826,
+                "right": 4026,
+                "top": 507.5,
                 "width": 200,
-                "x": 1908.5,
-                "y": 497.5
+                "x": 3826,
+                "y": 507.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput_h5": {
@@ -1752,7 +1969,7 @@
                 {
                     "label": null,
                     "output_name": "output_embed",
-                    "uuid": "424a55b1-2538-4a47-9593-3efad6bcc769"
+                    "uuid": "330ddaaa-f0f0-40b2-b732-2834ff9f04a4"
                 }
             ]
         },
@@ -1781,16 +1998,21 @@
                 }
             ],
             "position": {
-                "bottom": 78.5,
+                "bottom": 88.5,
                 "height": 202,
-                "left": 2186.5,
-                "right": 2386.5,
-                "top": -123.5,
+                "left": 4104,
+                "right": 4304,
+                "top": -113.5,
                 "width": 200,
-                "x": 2186.5,
-                "y": -123.5
+                "x": 4104,
+                "y": -113.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                },
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1798,10 +2020,10 @@
                 }
             },
             "tool_id": "__MERGE_COLLECTION__",
-            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "30d07b08-fe9d-4d21-8388-0795d35db7e1",
+            "uuid": "fad780b1-7920-46c4-9fbf-a1e16500b9ca",
             "workflow_outputs": []
         },
         "32": {
@@ -1815,7 +2037,12 @@
                     "output_name": "output_h5"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter failed",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Filter failed",
             "outputs": [
@@ -1825,26 +2052,32 @@
                 }
             ],
             "position": {
-                "bottom": 664.5,
+                "bottom": 674.5,
                 "height": 112,
-                "left": 2186.5,
-                "right": 2386.5,
-                "top": 552.5,
+                "left": 4104,
+                "right": 4304,
+                "top": 562.5,
                 "width": 200,
-                "x": 2186.5,
-                "y": 552.5
+                "x": 4104,
+                "y": 562.5
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "DeleteIntermediatesActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output"
+                }
+            },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "2f3fde2d-6f52-45a7-8ca0-ba3ae1cccaf3",
+            "uuid": "84eeb9b8-79f5-477f-b252-8004ceed8f6f",
             "workflow_outputs": [
                 {
                     "label": "input dataset(s) (filtered failed datasets)",
                     "output_name": "output",
-                    "uuid": "78fabe4f-6990-4329-a1d9-1dd8b6eb60ef"
+                    "uuid": "762bf5e8-433a-4ffe-b6a5-c29305d6c61d"
                 }
             ]
         },
@@ -1863,7 +2096,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers",
+                    "name": "groupby_file"
+                },
+                {
+                    "description": "runtime parameter for tool Scanpy FindMarkers",
+                    "name": "input_obj_file"
+                }
+            ],
             "label": "find_markers",
             "name": "Scanpy FindMarkers",
             "outputs": [
@@ -1877,16 +2119,21 @@
                 }
             ],
             "position": {
-                "bottom": 409.5,
+                "bottom": 419.5,
                 "height": 292,
-                "left": 2464.5,
-                "right": 2664.5,
-                "top": 117.5,
+                "left": 4382,
+                "right": 4582,
+                "top": 127.5,
                 "width": 200,
-                "x": 2464.5,
-                "y": 117.5
+                "x": 4382,
+                "y": 127.5
             },
             "post_job_actions": {
+                "DeleteIntermediatesActionoutput_h5ad": {
+                    "action_arguments": {},
+                    "action_type": "DeleteIntermediatesAction",
+                    "output_name": "output_h5ad"
+                },
                 "HideDatasetActionoutput_h5ad": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
@@ -1907,15 +2154,15 @@
                 "owner": "ebi-gxa",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"groupby\": \"INPUT_OBJ\", \"groupby_file\": {\"__class__\": \"ConnectedValue\"}, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"ConnectedValue\"}, \"n_genes\": \"100\", \"output_format\": \"anndata_h5ad\", \"output_markers\": \"true\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"markers_GROUPBY\", \"method\": \"t-test_overestim_var\", \"use_raw\": \"true\", \"rankby_abs\": \"false\", \"groups\": \"\", \"reference\": \"rest\", \"min_in_group_fraction\": \"0.0\", \"max_out_group_fraction\": \"1.0\", \"min_fold_change\": \"1.0\", \"pts\": \"false\", \"tie_correct\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"groupby\": \"INPUT_OBJ\", \"groupby_file\": {\"__class__\": \"RuntimeValue\"}, \"input_format\": \"anndata\", \"input_obj_file\": {\"__class__\": \"RuntimeValue\"}, \"n_genes\": \"100\", \"output_format\": \"anndata_h5ad\", \"output_markers\": \"true\", \"settings\": {\"default\": \"false\", \"__current_case__\": 1, \"key_added\": \"markers_GROUPBY\", \"method\": \"t-test_overestim_var\", \"use_raw\": \"true\", \"rankby_abs\": \"false\", \"groups\": \"\", \"reference\": \"rest\", \"min_in_group_fraction\": \"0.0\", \"max_out_group_fraction\": \"1.0\", \"min_fold_change\": \"1.0\", \"pts\": \"false\", \"tie_correct\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.6.0+galaxy4",
             "type": "tool",
-            "uuid": "c88a0424-a813-410a-a042-83326fa3ebbd",
+            "uuid": "5039cb89-8bb3-4f88-8d7d-0ce9c081aa3b",
             "workflow_outputs": [
                 {
                     "label": null,
                     "output_name": "output_tsv",
-                    "uuid": "55bcc812-4e9a-4fff-b6f1-6aa6e6ad3312"
+                    "uuid": "409c1ba5-cbcd-4492-99b1-45214f23cafd"
                 }
             ]
         },
@@ -1944,14 +2191,14 @@
                 }
             ],
             "position": {
-                "bottom": 672.5,
+                "bottom": 682.5,
                 "height": 202,
-                "left": 2464.5,
-                "right": 2664.5,
-                "top": 470.5,
+                "left": 4382,
+                "right": 4582,
+                "top": 480.5,
                 "width": 200,
-                "x": 2464.5,
-                "y": 470.5
+                "x": 4382,
+                "y": 480.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -1993,14 +2240,14 @@
                 }
             ],
             "position": {
-                "bottom": 507.5,
+                "bottom": 517.5,
                 "height": 132,
-                "left": 2742.5,
-                "right": 2942.5,
-                "top": 375.5,
+                "left": 4660,
+                "right": 4860,
+                "top": 385.5,
                 "width": 200,
-                "x": 2742.5,
-                "y": 375.5
+                "x": 4660,
+                "y": 385.5
             },
             "post_job_actions": {
                 "DeleteIntermediatesActionoutput": {
@@ -2062,14 +2309,14 @@
                 }
             ],
             "position": {
-                "bottom": 822.5,
+                "bottom": 832.5,
                 "height": 502,
-                "left": 3030.5,
-                "right": 3230.5,
-                "top": 320.5,
+                "left": 4948,
+                "right": 5148,
+                "top": 330.5,
                 "width": 200,
-                "x": 3030.5,
-                "y": 320.5
+                "x": 4948,
+                "y": 330.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_h5ad": {
@@ -2095,12 +2342,12 @@
                 {
                     "label": null,
                     "output_name": "output_h5ad",
-                    "uuid": "f42a9761-6841-4390-bd96-9065a51fa67a"
+                    "uuid": "fc75c7b8-aa79-4fd6-91a8-db6ade94ad71"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "0b208676-d14a-42ac-8d3a-d535dfc019ce",
-    "version": 13
+    "uuid": "48e6f224-f778-47ad-8e6c-e723570aa3c7",
+    "version": 16
 }

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -3,7 +3,7 @@ barcodes:
     optional: false
 cellmeta:
     optional: false
-clusering_slotnames:
+clustering_slotnames:
     replacements:
     -   __index__: 0
         find_pattern: (.*)
@@ -40,7 +40,7 @@ filter_genes:
     -   __index__: 0
         name: index
         subset:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 find_clusters:
     input_format: anndata
     method: louvain
@@ -56,7 +56,7 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
@@ -165,10 +165,10 @@ merge_group_slotnames:
     inputs:
     -   __index__: 0
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
     -   __index__: 1
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 merged_embeddings:
     advanced:
         conflict:
@@ -221,7 +221,7 @@ neighbours for umap:
         metric: euclidean
         n_neighbors: '15'
         n_neighbors_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         n_pcs: '50'
         random_seed: '0'
         use_rep: X_pca
@@ -303,7 +303,7 @@ run_tsne:
         n_pc: ''
         perplexity: '30.0'
         perplexity_file:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
         random_seed: '1234'
     use_rep: auto
 run_umap:

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -268,29 +268,6 @@ perplexity:
         input_values: 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50
         parameter_values: list_comma_separated_values
     parameter_name: perplexity
-plot_pca:
-    basis: pca
-    color_by: n_genes
-    components: ''
-    edges: 'false'
-    edges_color: ''
-    edges_width: '0.1'
-    fig_dpi: '80'
-    fig_fontsize: '10'
-    fig_frame: 'false'
-    fig_size: 7,7
-    fig_title: PCA
-    gene_symbols_field: ''
-    groups: ''
-    input_format: anndata
-    layer: ''
-    legend_fontsize: '10'
-    legend_loc: right margin
-    neighbors_key: ''
-    point_size: ''
-    projection: 2d
-    sort_order: 'false'
-    use_raw: 'true'
 resolution:
     __job_resource:
         __current_case__: 0

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -40,7 +40,7 @@ filter_genes:
     -   __index__: 0
         name: index
         subset:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
 find_clusters:
     input_format: anndata
     method: louvain
@@ -56,7 +56,7 @@ find_clusters:
         random_seed: '1234'
         resolution: '1.0'
         resolution_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         restrict_to: ''
         use_weights: 'false'
 find_markers:
@@ -177,10 +177,10 @@ merged_embeddings:
     inputs:
     -   __index__: 0
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
     -   __index__: 1
         input:
-            __class__: ConnectedValue
+            __class__: RuntimeValue
 meta_vars:
     input_type:
         __current_case__: 0
@@ -221,7 +221,7 @@ neighbours for umap:
         metric: euclidean
         n_neighbors: '15'
         n_neighbors_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         n_pcs: '50'
         random_seed: '0'
         use_rep: X_pca
@@ -303,7 +303,7 @@ run_tsne:
         n_pc: ''
         perplexity: '30.0'
         perplexity_file:
-            __class__: RuntimeValue
+            __class__: ConnectedValue
         random_seed: '1234'
     use_rep: auto
 run_umap:

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -229,6 +229,8 @@ normalise_data:
     export_mtx: 'true'
     input_format: anndata
     output_format: anndata_h5ad
+    save_layer: ''
+    save_raw: 'false'
     settings:
         __current_case__: 1
         default: 'false'
@@ -244,6 +246,8 @@ normalise_data_internal:
     export_mtx: 'false'
     input_format: anndata
     output_format: anndata_h5ad
+    save_layer: ''
+    save_raw: 'false'
     settings:
         __current_case__: 1
         default: 'false'

--- a/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
+++ b/w_smart-seq_clustering/scanpy_clustering_workflow_parameters.yaml
@@ -1,6 +1,8 @@
 Filtered cellgroup markers: {}
-barcodes: {}
-cellmeta: {}
+barcodes:
+    optional: false
+cellmeta:
+    optional: false
 clusering_slotnames:
     replacements:
     -   __index__: 0
@@ -90,8 +92,10 @@ find_variable_genes:
     n_top_gene: ''
     output_format: anndata_h5ad
     span: '0.3'
-genes: {}
-gtf: {}
+genes:
+    optional: false
+gtf:
+    optional: false
 harmony_batch:
     adjusted_basis: X_pca
     basis: X_pca
@@ -113,6 +117,9 @@ make_project_file:
             contains: umap
         embedding_sources:
             __class__: ConnectedValue
+    copy_l:
+        __current_case__: 1
+        default: 'false'
     copy_o:
         __current_case__: 0
         default: 'true'
@@ -120,6 +127,11 @@ make_project_file:
         -   __index__: 0
             contains: louvain
         obs_sources:
+            __class__: ConnectedValue
+    copy_r:
+        __current_case__: 0
+        default: 'true'
+        r_source:
             __class__: ConnectedValue
     copy_u:
         __current_case__: 0
@@ -129,13 +141,22 @@ make_project_file:
             contains: marker
         uns_sources:
             __class__: ConnectedValue
+    copy_x:
+        __current_case__: 0
+        default: 'true'
+        xlayers:
+        -   __index__: 0
+            dest: filtered
+            x_source:
+                __class__: ConnectedValue
     gene_flags: []
     gene_symbols_field: index
     modifications: []
     output_format: anndata_h5ad
     sanitize_varm: 'false'
     top_genes: '50'
-matrix: {}
+matrix:
+    optional: false
 merge_group_slotnames:
     advanced:
         conflict:
@@ -218,7 +239,6 @@ normalise_data:
         layer_norm: ''
         layers: ''
         log_transform: 'false'
-        save_raw: 'true'
         scale_factor: '1000000.0'
 normalise_data_internal:
     export_mtx: 'false'
@@ -234,8 +254,7 @@ normalise_data_internal:
         layer_norm: ''
         layers: ''
         log_transform: 'true'
-        save_raw: 'true'
-        scale_factor: '10000.0'
+        scale_factor: '1000000.0'
 perplexity:
     __job_resource:
         __current_case__: 0


### PR DESCRIPTION
This PR moves us to the workflow shown at http://galaxy-gxa-002:8090/u/jon/w/scanpy-prod-160-clustering-with-harmony-batch-adjustment-h5ad---groupby-as-file-v022-imported-from-uploaded-file. 

Principally, matrix handling has been changed such that:

- Normalised matrices are no longer stored in .raw (this will make intermediate anndata objects smaller)
- After the final merge step:
  - Raw values are stored in .raw (having removed any obs not present due to filtering)
  - Gene-filtered values are stored in a layer called 'filtered'
  - .X contains the normalised and log-transformed values present at the end of the main flow of the workflow

I also remove an unused plot step.

I think this covers most use cases. We could also store a pre-transform variant in layers, but I think that would be overkill and we don't want excessively large objects. 