### PR TITLE
Adapt hackathon changes into production

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Index(['age', 'cause_of_death', 'developmental_stage', 'disease', 'individual',
        'doublet_score', 'predicted_doublet', 'n_genes_by_counts',
        'log1p_n_genes_by_counts', 'total_counts', 'log1p_total_counts',
        'total_counts_mito', 'log1p_total_counts_mito', 'pct_counts_mito',
-       'n_counts', 'louvain_resolution_0.1', 'louvain_resolution_0.3',
-       'louvain_resolution_0.5', 'louvain_resolution_0.7',
-       'louvain_resolution_1.0', 'louvain_resolution_2.0',
-       'louvain_resolution_3.0', 'louvain_resolution_4.0',
-       'louvain_resolution_5.0'],
+       'n_counts', 'leiden_resolution_0.1', 'leiden_resolution_0.3',
+       'leiden_resolution_0.5', 'leiden_resolution_0.7',
+       'leiden_resolution_1.0', 'leiden_resolution_2.0',
+       'leiden_resolution_3.0', 'leiden_resolution_4.0',
+       'leiden_resolution_5.0'],
       dtype='object')
 ```
 
@@ -196,5 +196,5 @@ Marker genes are currently stored in .uns alongside unstructured metadata, and a
 
 ```
 >>> list(filter(lambda x: 'marker' in x, adata.uns.keys()))
-['markers_authors_cell_type_-_ontology_labels', 'markers_authors_cell_type_-_ontology_labels_filtered', 'markers_louvain_resolution_0.1', 'markers_louvain_resolution_0.1_filtered', 'markers_louvain_resolution_0.3', 'markers_louvain_resolution_0.3_filtered', 'markers_louvain_resolution_0.5', 'markers_louvain_resolution_0.5_filtered', 'markers_louvain_resolution_0.7', 'markers_louvain_resolution_0.7_filtered', 'markers_louvain_resolution_1.0', 'markers_louvain_resolution_1.0_filtered', 'markers_louvain_resolution_2.0', 'markers_louvain_resolution_2.0_filtered', 'markers_louvain_resolution_3.0', 'markers_louvain_resolution_3.0_filtered', 'markers_louvain_resolution_4.0', 'markers_louvain_resolution_4.0_filtered', 'markers_louvain_resolution_5.0', 'markers_louvain_resolution_5.0_filtered']
+['markers_authors_cell_type_-_ontology_labels', 'markers_authors_cell_type_-_ontology_labels_filtered', 'markers_leiden_resolution_0.1', 'markers_leiden_resolution_0.1_filtered', 'markers_leiden_resolution_0.3', 'markers_leiden_resolution_0.3_filtered', 'markers_leiden_resolution_0.5', 'markers_leiden_resolution_0.5_filtered', 'markers_leiden_resolution_0.7', 'markers_leiden_resolution_0.7_filtered', 'markers_leiden_resolution_1.0', 'markers_leiden_resolution_1.0_filtered', 'markers_leiden_resolution_2.0', 'markers_leiden_resolution_2.0_filtered', 'markers_leiden_resolution_3.0', 'markers_leiden_resolution_3.0_filtered', 'markers_leiden_resolution_4.0', 'markers_leiden_resolution_4.0_filtered', 'markers_leiden_resolution_5.0', 'markers_leiden_resolution_5.0_filtered']
 ```

--- a/bin/run_tertiary_workflow.sh
+++ b/bin/run_tertiary_workflow.sh
@@ -86,6 +86,7 @@ cp $gene_meta_file $SCXA_WORKDIR/$EXP_ID/$EXP_SPECIE/tertiary_data/genes_metadat
 
 # Run the workflow
 nextflow run $baseDir/w_tertiary/main.nf \
+    -profile atlas \
     --dir_path $SCXA_WORKDIR/$EXP_ID/$EXP_SPECIE/tertiary_data \
     --workdir $WORKDIR \
     --technology $FLAVOUR_NF \


### PR DESCRIPTION
Changes made here allow for changes made in the scxa-tertiary-workflow during the nf-core hackathon to be incorporated into production. Below are the changes made during the hackathon that are addressed in this PR:

- [x] Change in the clustering algorithm used (Louvain --> Leiden) (https://github.com/ebi-gene-expression-group/scxa-tertiary-workflow/pull/51)
- [x] Use of an atlas profile when running the tertiary workflow in production (https://github.com/ebi-gene-expression-group/scxa-tertiary-workflow/pull/55)

This PR should also bring the actual hackathon changes into the w_tertiary submodule:
- [x] Update `w_tertiary` submodule to the version that incorporates hackathon changes

Before merging, make sure that:
- [x] The [scxa-tertiary-workflows hackathon branch](https://github.com/ebi-gene-expression-group/scxa-tertiary-workflow/tree/hackathon) has been merged onto the `main` branch
- [x] The `w_tertiary` submodule in this branch has been pinned to the updated main branch in `scxa-tertiary-workflow`